### PR TITLE
Add env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ An `enwiro` is a local folder or a symbolic link pointing to a folder.
 An environment serves as a working directory for your applications, such as your
 terminal or your code editor.
 
+An environment variable `ENWIRO_ENV` containing the `enwiro` environment name
+will also be added before runnning commands with `enwiro wrap ...`.
+
 An environment could be linked to:
 
 - Any branch of a Git repository checked out on your local computer

--- a/enwiro/src/commands/wrap.rs
+++ b/enwiro/src/commands/wrap.rs
@@ -25,8 +25,8 @@ pub fn wrap<R: Read, W: Write>(
 ) -> Result<(), io::Error> {
     let selected_environment = context.get_or_cook_environment(&args.environment_name);
     let environment_path: String = match selected_environment {
-        Ok(environment) => environment.path,
-        Err(error) => match error.kind() {
+        Ok(ref environment) => environment.path.clone(),
+        Err(ref error) => match error.kind() {
             std::io::ErrorKind::NotFound => {
                 // shoudl be stderr write
                 context
@@ -47,6 +47,15 @@ pub fn wrap<R: Read, W: Write>(
         },
     };
     env::set_current_dir(environment_path).expect("Failed to change directory");
+
+
+    let environment_name: String = match selected_environment {
+        Ok(ref environment) => environment.name.clone(),
+        Err(_) => String::from(""),
+    };
+    unsafe {
+        env::set_var("ENWIRO_ENV", environment_name);
+    }
 
     let mut child = Command::new(args.command_name)
         .args(match args.child_args {


### PR DESCRIPTION
`enwiro wrap` will also add a `$ENWIRO_ENV` environment variable for use with scripts, such as attaching to a tmux session with the same name as the environment.

For instance, I'm using this with the following script (named `enwiro-tmux` and in my `$PATH`) :+1: 

```bash
#!/bin/bash
tmux new -A -s "${ENWIRO_ENV:-home}" -f active-pane
```

and I can then launch a new terminal and create or attach to an enwiro-picked tmux session with a keybind in my i3 config : 

```
bindsym $mod+Mod1+Return exec enwiro wrap terminal -- -e enwiro-tmux
```
