### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "assertables",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.1...enwiro-adapter-i3wm-v0.1.2) - 2026-02-10
+
+### Fixed
+
+- *(deps)* update rust crate clap to 4.5.4
+- *(deps)* update rust crate tokio to 1.37.0
+- *(deps)* update rust crate clap to 4.5.3
+
+### Other
+
+- set up release-plz
+- replace panics with anyhow error propagation
+- Add more details to READMEs
+- use char instead of string for single char split

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.1...enwiro-cookbook-git-v0.1.2) - 2026-02-10
+
+### Fixed
+
+- *(deps)* update rust crate git2 to 0.20.0
+- *(deps)* update rust crate confy to v2
+- *(deps)* update rust crate clap to 4.5.4
+
+### Other
+
+- set up release-plz
+- replace panics with anyhow error propagation
+- apply auto formatting

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.4](https://github.com/kantord/enwiro/compare/enwiro-v0.3.3...enwiro-v0.3.4) - 2026-02-10
+
+### Added
+
+- add current environment name as env variable
+
+### Fixed
+
+- fix error message
+- *(deps)* update rust crate confy to v2
+- *(deps)* update strum monorepo to 0.27.0
+
+### Other
+
+- set up release-plz
+- replace panics with anyhow error propagation
+- *(deps)* update rust crate rstest to 0.26.0
+- remove unsafe block for setting env
+- *(deps)* update rust crate assertables to v9
+- remove deprecated env::home_dir call
+- fix clippy issues
+- better handling of temporary folders
+- apply auto formatting
+- update rand crate
+- minor style fixes

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.3 -> 0.3.4
* `enwiro-adapter-i3wm`: 0.1.1 -> 0.1.2
* `enwiro-cookbook-git`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.4](https://github.com/kantord/enwiro/compare/enwiro-v0.3.3...enwiro-v0.3.4) - 2026-02-10

### Added

- add current environment name as env variable

### Fixed

- fix error message
- *(deps)* update rust crate confy to v2
- *(deps)* update strum monorepo to 0.27.0

### Other

- set up release-plz
- replace panics with anyhow error propagation
- *(deps)* update rust crate rstest to 0.26.0
- remove unsafe block for setting env
- *(deps)* update rust crate assertables to v9
- remove deprecated env::home_dir call
- fix clippy issues
- better handling of temporary folders
- apply auto formatting
- update rand crate
- minor style fixes
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.1...enwiro-adapter-i3wm-v0.1.2) - 2026-02-10

### Fixed

- *(deps)* update rust crate clap to 4.5.4
- *(deps)* update rust crate tokio to 1.37.0
- *(deps)* update rust crate clap to 4.5.3

### Other

- set up release-plz
- replace panics with anyhow error propagation
- Add more details to READMEs
- use char instead of string for single char split
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.1...enwiro-cookbook-git-v0.1.2) - 2026-02-10

### Fixed

- *(deps)* update rust crate git2 to 0.20.0
- *(deps)* update rust crate confy to v2
- *(deps)* update rust crate clap to 4.5.4

### Other

- set up release-plz
- replace panics with anyhow error propagation
- apply auto formatting
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).