### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "assertables",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.2...enwiro-adapter-i3wm-v0.1.3) - 2026-02-11
+
+### Other
+
+- update readme
+- use 2024 rust edition
+
 ## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.1...enwiro-adapter-i3wm-v0.1.2) - 2026-02-10
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.2...enwiro-cookbook-git-v0.1.3) - 2026-02-11
+
+### Other
+
+- update readme
+- add prek
+- add missing readme files
+- use 2024 rust edition
+
 ## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.1...enwiro-cookbook-git-v0.1.2) - 2026-02-10
 
 ### Fixed

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/kantord/enwiro/compare/enwiro-v0.3.4...enwiro-v0.3.5) - 2026-02-11
+
+### Fixed
+
+- cook environment from adapter name when no explicit name is given
+- reject invalid UTF-8 from cookbook subprocess output
+- check subprocess exit status in CookbookClient
+- write error mesage to stderr, not stdout
+
+### Other
+
+- update readme
+- split name resolution from environment lookup internally
+- test multiple cookbooks
+- replace unwrap anti-pattern with match in get_or_cook_environment
+- make more things testable through traits
+- add prek
+- add missing readme files
+- fix typo
+- use 2024 rust edition
+
 ## [0.3.4](https://github.com/kantord/enwiro/compare/enwiro-v0.3.3...enwiro-v0.3.4) - 2026-02-10
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.4 -> 0.3.5
* `enwiro-adapter-i3wm`: 0.1.2 -> 0.1.3
* `enwiro-cookbook-git`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.5](https://github.com/kantord/enwiro/compare/enwiro-v0.3.4...enwiro-v0.3.5) - 2026-02-11

### Fixed

- cook environment from adapter name when no explicit name is given
- reject invalid UTF-8 from cookbook subprocess output
- check subprocess exit status in CookbookClient
- write error mesage to stderr, not stdout

### Other

- update readme
- split name resolution from environment lookup internally
- test multiple cookbooks
- replace unwrap anti-pattern with match in get_or_cook_environment
- make more things testable through traits
- add prek
- add missing readme files
- fix typo
- use 2024 rust edition
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.2...enwiro-adapter-i3wm-v0.1.3) - 2026-02-11

### Other

- update readme
- use 2024 rust edition
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.2...enwiro-cookbook-git-v0.1.3) - 2026-02-11

### Other

- update readme
- add prek
- add missing readme files
- use 2024 rust edition
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).