### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "assertables",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.4...enwiro-adapter-i3wm-v0.1.5) - 2026-02-12
+
+### Added
+
+- add rofi bridge
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.3...enwiro-adapter-i3wm-v0.1.4) - 2026-02-11
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/kantord/enwiro/compare/enwiro-v0.3.6...enwiro-v0.3.7) - 2026-02-12
+
+### Added
+
+- add rofi bridge
+
 ## [0.3.6](https://github.com/kantord/enwiro/compare/enwiro-v0.3.5...enwiro-v0.3.6) - 2026-02-11
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.6 -> 0.3.7
* `enwiro-adapter-i3wm`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.7](https://github.com/kantord/enwiro/compare/enwiro-v0.3.6...enwiro-v0.3.7) - 2026-02-12

### Added

- add rofi bridge
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.4...enwiro-adapter-i3wm-v0.1.5) - 2026-02-12

### Added

- add rofi bridge
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).