### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "assertables",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "enwiro-logging",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.5...enwiro-adapter-i3wm-v0.1.6) - 2026-02-13
+
+### Added
+
+- extend logging to other binaries
+
 ## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.4...enwiro-adapter-i3wm-v0.1.5) - 2026-02-12
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.1...enwiro-bridge-rofi-v0.1.2) - 2026-02-13
+
+### Added
+
+- extend logging to other binaries
+
 ## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.0...enwiro-bridge-rofi-v0.1.1) - 2026-02-12
 
 ### Fixed

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.0...enwiro-cookbook-chezmoi-v0.1.1) - 2026-02-13
+
+### Added
+
+- extend logging to other binaries

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.3...enwiro-cookbook-git-v0.1.4) - 2026-02-13
+
+### Added
+
+- extend logging to other binaries
+
 ## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.2...enwiro-cookbook-git-v0.1.3) - 2026-02-11
 
 ### Other

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11](https://github.com/kantord/enwiro/compare/enwiro-v0.3.10...enwiro-v0.3.11) - 2026-02-13
+
+### Added
+
+- extend logging to other binaries
+
 ## [0.3.10](https://github.com/kantord/enwiro/compare/enwiro-v0.3.9...enwiro-v0.3.10) - 2026-02-13
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.10 -> 0.3.11
* `enwiro-adapter-i3wm`: 0.1.5 -> 0.1.6
* `enwiro-bridge-rofi`: 0.1.1 -> 0.1.2
* `enwiro-cookbook-chezmoi`: 0.1.0 -> 0.1.1
* `enwiro-cookbook-git`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.11](https://github.com/kantord/enwiro/compare/enwiro-v0.3.10...enwiro-v0.3.11) - 2026-02-13

### Added

- extend logging to other binaries
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.5...enwiro-adapter-i3wm-v0.1.6) - 2026-02-13

### Added

- extend logging to other binaries
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.1...enwiro-bridge-rofi-v0.1.2) - 2026-02-13

### Added

- extend logging to other binaries
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.0...enwiro-cookbook-chezmoi-v0.1.1) - 2026-02-13

### Added

- extend logging to other binaries
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.3...enwiro-cookbook-git-v0.1.4) - 2026-02-13

### Added

- extend logging to other binaries
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).