### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "assertables",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.5...enwiro-cookbook-git-v0.1.6) - 2026-02-14
+
+### Added
+
+- *(cookbook-git)* worktrees on demand for branch-based recipes
+
+### Fixed
+
+- *(cookbook-git)* log worktree discovery errors
+
 ## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.4...enwiro-cookbook-git-v0.1.5) - 2026-02-13
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/kantord/enwiro/compare/enwiro-v0.3.11...enwiro-v0.3.12) - 2026-02-14
+
+### Fixed
+
+- *(enwiro)* handle slashes in recipe names
+
 ## [0.3.11](https://github.com/kantord/enwiro/compare/enwiro-v0.3.10...enwiro-v0.3.11) - 2026-02-13
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.11 -> 0.3.12
* `enwiro-cookbook-git`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.12](https://github.com/kantord/enwiro/compare/enwiro-v0.3.11...enwiro-v0.3.12) - 2026-02-14

### Fixed

- *(enwiro)* handle slashes in recipe names
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.5...enwiro-cookbook-git-v0.1.6) - 2026-02-14

### Added

- *(cookbook-git)* worktrees on demand for branch-based recipes

### Fixed

- *(cookbook-git)* log worktree discovery errors
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).