### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "assertables",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "enwiro-logging",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.4...enwiro-bridge-rofi-v0.1.5) - 2026-02-15
+
+### Added
+
+- add optional description field to recipes
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.3...enwiro-bridge-rofi-v0.1.4) - 2026-02-14
 
 ### Fixed

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.0...enwiro-cookbook-github-v0.1.1) - 2026-02-15
+
+### Added
+
+- add optional description field to recipes

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14](https://github.com/kantord/enwiro/compare/enwiro-v0.3.13...enwiro-v0.3.14) - 2026-02-15
+
+### Added
+
+- add optional description field to recipes
+
+### Fixed
+
+- fix performance issues in wrap command
+
 ## [0.3.13](https://github.com/kantord/enwiro/compare/enwiro-v0.3.12...enwiro-v0.3.13) - 2026-02-14
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.13 -> 0.3.14
* `enwiro-bridge-rofi`: 0.1.4 -> 0.1.5
* `enwiro-cookbook-github`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.14](https://github.com/kantord/enwiro/compare/enwiro-v0.3.13...enwiro-v0.3.14) - 2026-02-15

### Added

- add optional description field to recipes

### Fixed

- fix performance issues in wrap command
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.4...enwiro-bridge-rofi-v0.1.5) - 2026-02-15

### Added

- add optional description field to recipes
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.0...enwiro-cookbook-github-v0.1.1) - 2026-02-15

### Added

- add optional description field to recipes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).