### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "assertables",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.1...enwiro-cookbook-github-v0.1.2) - 2026-02-15
+
+### Added
+
+- *(enwiro-cookbook-github)* drop owner prefix from recipe names
+
 ## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.0...enwiro-cookbook-github-v0.1.1) - 2026-02-15
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/kantord/enwiro/compare/enwiro-v0.3.15...enwiro-v0.3.16) - 2026-02-15
+
+### Added
+
+- preserve metadata when cooking recipes
+
+### Other
+
+- co-locate metadata with environments
+
 ## [0.3.15](https://github.com/kantord/enwiro/compare/enwiro-v0.3.14...enwiro-v0.3.15) - 2026-02-15
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.15 -> 0.3.16
* `enwiro-cookbook-github`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.16](https://github.com/kantord/enwiro/compare/enwiro-v0.3.15...enwiro-v0.3.16) - 2026-02-15

### Added

- preserve metadata when cooking recipes

### Other

- co-locate metadata with environments
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.1...enwiro-cookbook-github-v0.1.2) - 2026-02-15

### Added

- *(enwiro-cookbook-github)* drop owner prefix from recipe names
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).