### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "anyhow",
  "assertables",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.1...enwiro-cookbook-chezmoi-v0.1.2) - 2026-02-20
+
+### Added
+
+- add metadata
+
 ## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.0...enwiro-cookbook-chezmoi-v0.1.1) - 2026-02-13
 
 ### Added

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.7...enwiro-cookbook-git-v0.1.8) - 2026-02-20
+
+### Added
+
+- *(cookbook-git)* sort recipes
+- add metadata
+
 ## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.6...enwiro-cookbook-git-v0.1.7) - 2026-02-18
 
 ### Fixed

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.3...enwiro-cookbook-github-v0.1.4) - 2026-02-20
+
+### Added
+
+- sort recipes by `updated_at`
+- add metadata
+
 ## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.2...enwiro-cookbook-github-v0.1.3) - 2026-02-19
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.18](https://github.com/kantord/enwiro/compare/enwiro-v0.3.17...enwiro-v0.3.18) - 2026-02-20
+
+### Added
+
+- do not show recipes that have already been cooked
+- add metadata
+- add a metadata field
+- use fixed sorting for cookbooks
+
 ## [0.3.17](https://github.com/kantord/enwiro/compare/enwiro-v0.3.16...enwiro-v0.3.17) - 2026-02-16
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.17 -> 0.3.18
* `enwiro-cookbook-chezmoi`: 0.1.1 -> 0.1.2
* `enwiro-cookbook-git`: 0.1.7 -> 0.1.8
* `enwiro-cookbook-github`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.18](https://github.com/kantord/enwiro/compare/enwiro-v0.3.17...enwiro-v0.3.18) - 2026-02-20

### Added

- do not show recipes that have already been cooked
- add metadata
- add a metadata field
- use fixed sorting for cookbooks
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.1...enwiro-cookbook-chezmoi-v0.1.2) - 2026-02-20

### Added

- add metadata
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.7...enwiro-cookbook-git-v0.1.8) - 2026-02-20

### Added

- *(cookbook-git)* sort recipes
- add metadata
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.3...enwiro-cookbook-github-v0.1.4) - 2026-02-20

### Added

- sort recipes by `updated_at`
- add metadata
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).