### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "assertables",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.6...enwiro-adapter-i3wm-v0.1.7) - 2026-04-11
+
+### Added
+
+- always use short workspace id for newly activated enwiro
+
 ## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.5...enwiro-adapter-i3wm-v0.1.6) - 2026-02-13
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.21](https://github.com/kantord/enwiro/compare/enwiro-v0.3.20...enwiro-v0.3.21) - 2026-04-11
+
+### Added
+
+- always use short workspace id for newly activated enwiro
+
 ## [0.3.20](https://github.com/kantord/enwiro/compare/enwiro-v0.3.19...enwiro-v0.3.20) - 2026-04-03
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.20"
+version = "0.3.21"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.20 -> 0.3.21
* `enwiro-adapter-i3wm`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.21](https://github.com/kantord/enwiro/compare/enwiro-v0.3.20...enwiro-v0.3.21) - 2026-04-11

### Added

- always use short workspace id for newly activated enwiro
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.6...enwiro-adapter-i3wm-v0.1.7) - 2026-04-11

### Added

- always use short workspace id for newly activated enwiro
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).