### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "anyhow",
  "assertables",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.7...enwiro-adapter-i3wm-v0.1.8) - 2026-04-12
+
+### Added
+
+- replace least-score eviction with NetBenefit swap selection
+
+### Other
+
+- replace frecency with percentile slot_score in ManagedEnvInfo
+
 ## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.6...enwiro-adapter-i3wm-v0.1.7) - 2026-04-11
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.23](https://github.com/kantord/enwiro/compare/enwiro-v0.3.22...enwiro-v0.3.23) - 2026-04-12
+
+### Other
+
+- add launcher_score and slot_scores wrappers in usage_stats
+- replace frecency with percentile slot_score in ManagedEnvInfo
+
 ## [0.3.22](https://github.com/kantord/enwiro/compare/enwiro-v0.3.21...enwiro-v0.3.22) - 2026-04-12
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.22"
+version = "0.3.23"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.22 -> 0.3.23
* `enwiro-adapter-i3wm`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.23](https://github.com/kantord/enwiro/compare/enwiro-v0.3.22...enwiro-v0.3.23) - 2026-04-12

### Other

- add launcher_score and slot_scores wrappers in usage_stats
- replace frecency with percentile slot_score in ManagedEnvInfo
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.7...enwiro-adapter-i3wm-v0.1.8) - 2026-04-12

### Added

- replace least-score eviction with NetBenefit swap selection

### Other

- replace frecency with percentile slot_score in ManagedEnvInfo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).