### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "anyhow",
  "assertables",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.9...enwiro-cookbook-git-v0.1.10) - 2026-04-13
+
+### Fixed
+
+- surface full error chain in notifications and handle branch already checked out
+
 ## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.8...enwiro-cookbook-git-v0.1.9) - 2026-04-03
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.25](https://github.com/kantord/enwiro/compare/enwiro-v0.3.24...enwiro-v0.3.25) - 2026-04-13
+
+### Fixed
+
+- surface full error chain in notifications and handle branch already checked out
+- list-all no longer kills user-managed daemon on every invocation
+
 ## [0.3.24](https://github.com/kantord/enwiro/compare/enwiro-v0.3.23...enwiro-v0.3.24) - 2026-04-13
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.24 -> 0.3.25
* `enwiro-cookbook-git`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.25](https://github.com/kantord/enwiro/compare/enwiro-v0.3.24...enwiro-v0.3.25) - 2026-04-13

### Fixed

- surface full error chain in notifications and handle branch already checked out
- list-all no longer kills user-managed daemon on every invocation
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.9...enwiro-cookbook-git-v0.1.10) - 2026-04-13

### Fixed

- surface full error chain in notifications and handle branch already checked out
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).