### PR TITLE
docs: update README to reflect always-running daemon model

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,15 @@ List of currently available bridges:
 
 ### Background Recipe Caching
 
-When you run `enwiro list-all` (or use it via a bridge like rofi), a background
-daemon is automatically spawned to keep recipe listings cached. This avoids
-blocking the UI on slow cookbook plugins (e.g., GitHub API calls).
+A background daemon keeps recipe listings cached to avoid blocking the UI on slow
+cookbook plugins (e.g., GitHub API calls). Start it with:
 
-- The daemon starts automatically on first use — no manual setup needed
-- A desktop notification is shown when the daemon starts for the first time
-- Recipes are refreshed every 5 minutes in the background
-- The daemon exits automatically after 1 hour of inactivity
+```
+enwiro daemon
+```
+
+- Recipes are refreshed every 5 minutes while the user is active
+- The daemon runs until stopped (SIGTERM/SIGINT/SIGHUP cause a clean shutdown)
 - If the cache is unavailable, `list-all` falls back to fetching recipes synchronously
 
 Runtime files are stored in `$XDG_RUNTIME_DIR/enwiro/` (or `$XDG_CACHE_HOME/enwiro/run/`


### PR DESCRIPTION
fixes #264 


The old text described an auto-spawning, self-terminating daemon — both no longer true. This replaces it with the current behaviour: manual start via enwiro daemon, runs until signalled, cache refresh gated on user activity.