### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "anyhow",
  "assertables",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.9...enwiro-adapter-i3wm-v0.1.10) - 2026-04-16
+
+### Fixed
+
+- *(enwiro-adapter-i3wm)* always place newly activated workspace in shortcut zone
+
 ## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.8...enwiro-adapter-i3wm-v0.1.9) - 2026-04-13
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.6...enwiro-cookbook-github-v0.1.7) - 2026-04-16
+
+### Fixed
+
+- *(enwiro-cookbook-github)* dont die on gh 100-result truncation
+
 ## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.5...enwiro-cookbook-github-v0.1.6) - 2026-04-14
 
 ### Fixed

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.26](https://github.com/kantord/enwiro/compare/enwiro-v0.3.25...enwiro-v0.3.26) - 2026-04-16
+
+### Fixed
+
+- *(enwiro-adapter-i3wm)* always place newly activated workspace in shortcut zone
+
 ## [0.3.25](https://github.com/kantord/enwiro/compare/enwiro-v0.3.24...enwiro-v0.3.25) - 2026-04-13
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.25 -> 0.3.26
* `enwiro-adapter-i3wm`: 0.1.9 -> 0.1.10
* `enwiro-cookbook-github`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.26](https://github.com/kantord/enwiro/compare/enwiro-v0.3.25...enwiro-v0.3.26) - 2026-04-16

### Fixed

- *(enwiro-adapter-i3wm)* always place newly activated workspace in shortcut zone
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.9...enwiro-adapter-i3wm-v0.1.10) - 2026-04-16

### Fixed

- *(enwiro-adapter-i3wm)* always place newly activated workspace in shortcut zone
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.6...enwiro-cookbook-github-v0.1.7) - 2026-04-16

### Fixed

- *(enwiro-cookbook-github)* dont die on gh 100-result truncation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).