### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "anyhow",
  "assertables",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "enwiro-logging",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.10...enwiro-adapter-i3wm-v0.1.11) - 2026-05-09
+
+### Added
+
+- shorten binary name to enw
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.9...enwiro-adapter-i3wm-v0.1.10) - 2026-04-16
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.0...enwiro-adapter-tmux-v0.1.1) - 2026-05-09
+
+### Added
+
+- shorten binary name to enw

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.7...enwiro-bridge-rofi-v0.1.8) - 2026-05-09
+
+### Added
+
+- shorten binary name to enw
+
 ## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.6...enwiro-bridge-rofi-v0.1.7) - 2026-04-03
 
 ### Fixed

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.27](https://github.com/kantord/enwiro/compare/enwiro-v0.3.26...enwiro-v0.3.27) - 2026-05-09
+
+### Added
+
+- shorten binary name to enw
+
 ## [0.3.26](https://github.com/kantord/enwiro/compare/enwiro-v0.3.25...enwiro-v0.3.26) - 2026-04-16
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.26"
+version = "0.3.27"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.26 -> 0.3.27
* `enwiro-adapter-i3wm`: 0.1.10 -> 0.1.11
* `enwiro-adapter-tmux`: 0.1.0 -> 0.1.1
* `enwiro-bridge-rofi`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.27](https://github.com/kantord/enwiro/compare/enwiro-v0.3.26...enwiro-v0.3.27) - 2026-05-09

### Added

- shorten binary name to enw
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.10...enwiro-adapter-i3wm-v0.1.11) - 2026-05-09

### Added

- shorten binary name to enw
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.0...enwiro-adapter-tmux-v0.1.1) - 2026-05-09

### Added

- shorten binary name to enw
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.7...enwiro-bridge-rofi-v0.1.8) - 2026-05-09

### Added

- shorten binary name to enw
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).