### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "anyhow",
  "assertables",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.2.0" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.2.1" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.13...enwiro-adapter-i3wm-v0.1.14) - 2026-05-11
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.12...enwiro-adapter-i3wm-v0.1.13) - 2026-05-11
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.2...enwiro-adapter-tmux-v0.1.3) - 2026-05-11
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.1...enwiro-adapter-tmux-v0.1.2) - 2026-05-10
 
 ### Added

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.9...enwiro-bridge-rofi-v0.1.10) - 2026-05-11
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.8...enwiro-bridge-rofi-v0.1.9) - 2026-05-10
 
 ### Added

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.4...enwiro-cookbook-chezmoi-v0.1.5) - 2026-05-11
+
+### Other
+
+- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.3...enwiro-cookbook-chezmoi-v0.1.4) - 2026-05-10
 
 ### Added

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.11...enwiro-cookbook-git-v0.1.12) - 2026-05-11
+
+### Other
+
+- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
+
 ## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.10...enwiro-cookbook-git-v0.1.11) - 2026-05-10
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.8...enwiro-cookbook-github-v0.1.9) - 2026-05-11
+
+### Other
+
+- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
+
 ## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.7...enwiro-cookbook-github-v0.1.8) - 2026-05-10
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.1...enwiro-cookbook-obsidian-v0.1.2) - 2026-05-11
+
+### Other
+
+- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
+
 ## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.0...enwiro-cookbook-obsidian-v0.1.1) - 2026-05-10
 
 ### Added

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.2.0...enwiro-sdk-v0.2.1) - 2026-05-11
+
+### Other
+
+- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
+
 ## [0.2.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.1.0...enwiro-sdk-v0.2.0) - 2026-05-10
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.29](https://github.com/kantord/enwiro/compare/enwiro-v0.3.28...enwiro-v0.3.29) - 2026-05-11
+
+### Other
+
+- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
+
 ## [0.3.28](https://github.com/kantord/enwiro/compare/enwiro-v0.3.27...enwiro-v0.3.28) - 2026-05-10
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `enwiro`: 0.3.28 -> 0.3.29
* `enwiro-cookbook-chezmoi`: 0.1.4 -> 0.1.5
* `enwiro-cookbook-git`: 0.1.11 -> 0.1.12
* `enwiro-cookbook-github`: 0.1.8 -> 0.1.9
* `enwiro-cookbook-obsidian`: 0.1.1 -> 0.1.2
* `enwiro-adapter-i3wm`: 0.1.13 -> 0.1.14
* `enwiro-adapter-tmux`: 0.1.2 -> 0.1.3
* `enwiro-bridge-rofi`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.2.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.2.0...enwiro-sdk-v0.2.1) - 2026-05-11

### Other

- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.29](https://github.com/kantord/enwiro/compare/enwiro-v0.3.28...enwiro-v0.3.29) - 2026-05-11

### Other

- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.4...enwiro-cookbook-chezmoi-v0.1.5) - 2026-05-11

### Other

- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.11...enwiro-cookbook-git-v0.1.12) - 2026-05-11

### Other

- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.8...enwiro-cookbook-github-v0.1.9) - 2026-05-11

### Other

- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.1...enwiro-cookbook-obsidian-v0.1.2) - 2026-05-11

### Other

- move shared types to sdk create ([#353](https://github.com/kantord/enwiro/pull/353))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.13...enwiro-adapter-i3wm-v0.1.14) - 2026-05-11

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.2...enwiro-adapter-tmux-v0.1.3) - 2026-05-11

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.9...enwiro-bridge-rofi-v0.1.10) - 2026-05-11

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).