### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "assertables",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.17...enwiro-adapter-i3wm-v0.1.18) - 2026-05-17
+
+### Fixed
+
+- *(adapter-i3wm)* avoid empty-workspace race in activate rebalance ([#390](https://github.com/kantord/enwiro/pull/390))
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.16...enwiro-adapter-i3wm-v0.1.17) - 2026-05-16
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.32](https://github.com/kantord/enwiro/compare/enwiro-v0.3.31...enwiro-v0.3.32) - 2026-05-17
+
+### Added
+
+- add submodules garnish with autorun hooks ([#398](https://github.com/kantord/enwiro/pull/398))
+- add "just" garnish
+
+### Other
+
+- .
+
 ## [0.3.31](https://github.com/kantord/enwiro/compare/enwiro-v0.3.30...enwiro-v0.3.31) - 2026-05-13
 
 ### Other

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.31"
+version = "0.3.32"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.31 -> 0.3.32
* `enwiro-adapter-i3wm`: 0.1.17 -> 0.1.18

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.32](https://github.com/kantord/enwiro/compare/enwiro-v0.3.31...enwiro-v0.3.32) - 2026-05-17

### Added

- add submodules garnish with autorun hooks ([#398](https://github.com/kantord/enwiro/pull/398))
- add "just" garnish

### Other

- .
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.17...enwiro-adapter-i3wm-v0.1.18) - 2026-05-17

### Fixed

- *(adapter-i3wm)* avoid empty-workspace race in activate rebalance ([#390](https://github.com/kantord/enwiro/pull/390))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).