### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.32"
+version = "0.3.33"
 dependencies = [
  "anyhow",
  "assertables",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "confy",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.2.3" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.2" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.3.0" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.3" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.18...enwiro-adapter-i3wm-v0.1.19) - 2026-05-17
+
+### Fixed
+
+- *(deps)* update rust crate toml to v1 ([#422](https://github.com/kantord/enwiro/pull/422))
+
 ## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.17...enwiro-adapter-i3wm-v0.1.18) - 2026-05-17
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.4...enwiro-adapter-tmux-v0.1.5) - 2026-05-17
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.3...enwiro-adapter-tmux-v0.1.4) - 2026-05-13
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.11...enwiro-bridge-rofi-v0.1.12) - 2026-05-17
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.10...enwiro-bridge-rofi-v0.1.11) - 2026-05-13
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.6...enwiro-cookbook-chezmoi-v0.1.7) - 2026-05-17
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.5...enwiro-cookbook-chezmoi-v0.1.6) - 2026-05-13
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.13...enwiro-cookbook-git-v0.1.14) - 2026-05-17
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.12...enwiro-cookbook-git-v0.1.13) - 2026-05-13
 
 ### Other

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.10...enwiro-cookbook-github-v0.1.11) - 2026-05-17
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.9...enwiro-cookbook-github-v0.1.10) - 2026-05-13
 
 ### Other

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.3...enwiro-cookbook-obsidian-v0.1.4) - 2026-05-17
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.2...enwiro-cookbook-obsidian-v0.1.3) - 2026-05-13
 
 ### Other

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.2...enwiro-daemon-v0.0.3) - 2026-05-17
+
+### Fixed
+
+- *(deps)* update rust crate signal-hook to 0.4 ([#420](https://github.com/kantord/enwiro/pull/420))
+
 ## [0.0.2](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.1...enwiro-daemon-v0.0.2) - 2026-05-15
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.0...enwiro-garnish-just-v0.1.1) - 2026-05-17
+
+### Added
+
+- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.0...enwiro-garnish-submodules-v0.1.1) - 2026-05-17
+
+### Added
+
+- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.2.3...enwiro-sdk-v0.3.0) - 2026-05-17
+
+### Added
+
+- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))
+
+### Fixed
+
+- *(deps)* update strum monorepo to 0.28.0 ([#421](https://github.com/kantord/enwiro/pull/421))
+
 ## [0.2.2](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.2.1...enwiro-sdk-v0.2.2) - 2026-05-13
 
 ### Other

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.33](https://github.com/kantord/enwiro/compare/enwiro-v0.3.32...enwiro-v0.3.33) - 2026-05-17
+
+### Added
+
+- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))
+
+### Fixed
+
+- *(deps)* update strum monorepo to 0.28.0 ([#421](https://github.com/kantord/enwiro/pull/421))
+
 ## [0.3.32](https://github.com/kantord/enwiro/compare/enwiro-v0.3.31...enwiro-v0.3.32) - 2026-05-17
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)
* `enwiro-daemon`: 0.0.2 -> 0.0.3 (✓ API compatible changes)
* `enwiro`: 0.3.32 -> 0.3.33
* `enwiro-adapter-i3wm`: 0.1.18 -> 0.1.19
* `enwiro-garnish-just`: 0.1.0 -> 0.1.1
* `enwiro-garnish-submodules`: 0.1.0 -> 0.1.1
* `enwiro-adapter-tmux`: 0.1.4 -> 0.1.5
* `enwiro-bridge-rofi`: 0.1.11 -> 0.1.12
* `enwiro-cookbook-chezmoi`: 0.1.6 -> 0.1.7
* `enwiro-cookbook-git`: 0.1.13 -> 0.1.14
* `enwiro-cookbook-github`: 0.1.10 -> 0.1.11
* `enwiro-cookbook-obsidian`: 0.1.3 -> 0.1.4

### ⚠ `enwiro-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliEntry.require_confirmation in /tmp/.tmpgs0Fbt/enwiro/enwiro-sdk/src/gear.rs:155
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.3.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.2.3...enwiro-sdk-v0.3.0) - 2026-05-17

### Added

- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))

### Fixed

- *(deps)* update strum monorepo to 0.28.0 ([#421](https://github.com/kantord/enwiro/pull/421))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.3](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.2...enwiro-daemon-v0.0.3) - 2026-05-17

### Fixed

- *(deps)* update rust crate signal-hook to 0.4 ([#420](https://github.com/kantord/enwiro/pull/420))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.33](https://github.com/kantord/enwiro/compare/enwiro-v0.3.32...enwiro-v0.3.33) - 2026-05-17

### Added

- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))

### Fixed

- *(deps)* update strum monorepo to 0.28.0 ([#421](https://github.com/kantord/enwiro/pull/421))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.18...enwiro-adapter-i3wm-v0.1.19) - 2026-05-17

### Fixed

- *(deps)* update rust crate toml to v1 ([#422](https://github.com/kantord/enwiro/pull/422))
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.0...enwiro-garnish-just-v0.1.1) - 2026-05-17

### Added

- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.0...enwiro-garnish-submodules-v0.1.1) - 2026-05-17

### Added

- gate gear entries behind explicit -y confirmation ([#400](https://github.com/kantord/enwiro/pull/400))
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.4...enwiro-adapter-tmux-v0.1.5) - 2026-05-17

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.11...enwiro-bridge-rofi-v0.1.12) - 2026-05-17

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.6...enwiro-cookbook-chezmoi-v0.1.7) - 2026-05-17

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.13...enwiro-cookbook-git-v0.1.14) - 2026-05-17

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.10...enwiro-cookbook-github-v0.1.11) - 2026-05-17

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.3...enwiro-cookbook-obsidian-v0.1.4) - 2026-05-17

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).