### PR TITLE
feat: retain recipe id in EnvStats

### DIFF
--- a/enwiro-daemon/src/meta.rs
+++ b/enwiro-daemon/src/meta.rs
@@ -24,6 +24,8 @@ pub struct EnvStats {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cookbook: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe: Option<String>,
 }
 
 pub fn now_timestamp() -> i64 {
@@ -103,10 +105,16 @@ pub fn record_switch_per_env(env_dir: &Path, timestamp: i64) {
     }
 }
 
-/// Save cookbook and description metadata in per-env meta.json. Best-effort.
-pub fn record_cook_metadata_per_env(env_dir: &Path, cookbook: &str, description: Option<&str>) {
+/// Save cookbook, recipe, and description metadata in per-env meta.json. Best-effort.
+pub fn record_cook_metadata_per_env(
+    env_dir: &Path,
+    cookbook: &str,
+    recipe: &str,
+    description: Option<&str>,
+) {
     let mut meta = load_env_meta(env_dir);
     meta.cookbook = Some(cookbook.to_string());
+    meta.recipe = Some(recipe.to_string());
     if let Some(d) = description {
         meta.description = Some(d.to_string());
     }
@@ -151,11 +159,51 @@ mod tests {
         let env_dir = dir.path().join("my-project");
         fs::create_dir(&env_dir).unwrap();
 
-        record_cook_metadata_per_env(&env_dir, "github", Some("Fix auth bug"));
+        record_cook_metadata_per_env(
+            &env_dir,
+            "github",
+            "kantord/enwiro#325",
+            Some("Fix auth bug"),
+        );
 
         let meta = load_env_meta(&env_dir);
         assert_eq!(meta.cookbook, Some("github".to_string()));
+        assert_eq!(meta.recipe, Some("kantord/enwiro#325".to_string()));
         assert_eq!(meta.description, Some("Fix auth bug".to_string()));
+    }
+
+    #[test]
+    fn test_per_env_record_cook_metadata_persists_recipe() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_dir = dir.path().join("my-project");
+        fs::create_dir(&env_dir).unwrap();
+
+        record_cook_metadata_per_env(&env_dir, "github", "owner/repo#42", None);
+
+        let raw = fs::read_to_string(env_dir.join("meta.json")).unwrap();
+        assert!(
+            raw.contains("\"recipe\":\"owner/repo#42\""),
+            "meta.json must include the recipe field: {raw}"
+        );
+
+        let meta = load_env_meta(&env_dir);
+        assert_eq!(meta.recipe, Some("owner/repo#42".to_string()));
+    }
+
+    #[test]
+    fn test_env_stats_recipe_defaults_to_none_for_old_envs() {
+        let dir = tempfile::tempdir().unwrap();
+        let env_dir = dir.path().join("legacy");
+        fs::create_dir(&env_dir).unwrap();
+        fs::write(
+            env_dir.join("meta.json"),
+            r#"{"cookbook":"github","description":"old env"}"#,
+        )
+        .unwrap();
+
+        let meta = load_env_meta(&env_dir);
+        assert_eq!(meta.recipe, None);
+        assert_eq!(meta.cookbook, Some("github".to_string()));
     }
 
     #[test]
@@ -173,11 +221,12 @@ mod tests {
 
         record_activation_per_env(&env_dir);
         record_activation_per_env(&env_dir);
-        record_cook_metadata_per_env(&env_dir, "git", Some("My project"));
+        record_cook_metadata_per_env(&env_dir, "git", "my/project", Some("My project"));
 
         let meta = load_env_meta(&env_dir);
         assert_eq!(meta.signals.activation_buffer.len(), 2);
         assert_eq!(meta.cookbook, Some("git".to_string()));
+        assert_eq!(meta.recipe, Some("my/project".to_string()));
         assert_eq!(meta.description, Some("My project".to_string()));
     }
 

--- a/enwiro/src/commands/list_all.rs
+++ b/enwiro/src/commands/list_all.rs
@@ -496,6 +496,7 @@ mod tests {
             },
             description: Some("Fix auth bug".to_string()),
             cookbook: Some("github".to_string()),
+            recipe: Some("owner/repo#42".to_string()),
         };
         let env_dir = temp_dir.path().join("owner-repo#42");
         std::fs::write(

--- a/enwiro/src/context.rs
+++ b/enwiro/src/context.rs
@@ -79,7 +79,7 @@ impl<W: Write> CommandContext<W> {
         let env_path = cookbook.cook(name)?;
         let env = self.create_environment_symlink(name, &env_path)?;
         let flat_name = name.replace('/', "-");
-        self.save_cook_metadata(&flat_name, &cookbook_name, description.as_deref());
+        self.save_cook_metadata(&flat_name, &cookbook_name, name, description.as_deref());
         self.write_gear_if_present(cookbook.as_ref(), name, &flat_name);
         self.write_garnish_gear(&env_path, &flat_name);
         Ok(env)
@@ -107,9 +107,15 @@ impl<W: Write> CommandContext<W> {
         None
     }
 
-    fn save_cook_metadata(&self, env_name: &str, cookbook: &str, description: Option<&str>) {
+    fn save_cook_metadata(
+        &self,
+        env_name: &str,
+        cookbook: &str,
+        recipe: &str,
+        description: Option<&str>,
+    ) {
         let env_dir = Path::new(&self.config.workspaces_directory).join(env_name);
-        crate::usage_stats::record_cook_metadata_per_env(&env_dir, cookbook, description);
+        crate::usage_stats::record_cook_metadata_per_env(&env_dir, cookbook, recipe, description);
     }
 
     /// Run every discovered Garnish plugin against the cooked project;
@@ -685,6 +691,35 @@ mod tests {
         let env_dir = temp_dir.path().join("my-project");
         let meta = crate::usage_stats::load_env_meta(&env_dir);
         assert_eq!(meta.cookbook.as_deref(), Some("git"));
+        assert_eq!(meta.recipe.as_deref(), Some("my-project"));
+    }
+
+    #[rstest]
+    fn test_cook_environment_saves_unflattened_recipe_name(
+        context_object: (tempfile::TempDir, FakeContext, AdapterLog, NotificationLog),
+    ) {
+        let (temp_dir, mut context_object, _, _) = context_object;
+
+        let cooked_dir = temp_dir.path().join("cooked-target");
+        fs::create_dir(&cooked_dir).unwrap();
+
+        let recipe_name = "owner/repo#42";
+        context_object.write_cache_entry("github", recipe_name);
+        context_object.cookbooks = vec![Box::new(FakeCookbook::new(
+            "github",
+            vec![recipe_name],
+            vec![(recipe_name, cooked_dir.to_str().unwrap())],
+        ))];
+
+        context_object.cook_environment(recipe_name).unwrap();
+
+        let env_dir = temp_dir.path().join("owner-repo#42");
+        let meta = crate::usage_stats::load_env_meta(&env_dir);
+        assert_eq!(
+            meta.recipe.as_deref(),
+            Some(recipe_name),
+            "recipe must persist the unflattened id so refresh can re-run `cookbook gear <recipe>`"
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Persist the cookbook recipe id on every cook so refresh can re-run `cookbook gear <recipe>` without re-deriving it from the env name. Stored unflattened (pre `/` → `-`) on `EnvStats.recipe`; `Option` keeps old envs deserializing without migration.

that could be made stricter later once legacy data is gone

Closes #325