### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.36"
+version = "0.3.37"
 dependencies = [
  "anyhow",
  "assertables",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-i3-activitywatch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "hostname",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "enwiro-sdk",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.21...enwiro-adapter-i3wm-v0.1.22) - 2026-05-21
+
+### Added
+
+- unify list commands ([#487](https://github.com/kantord/enwiro/pull/487))
+
 ## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.20...enwiro-adapter-i3wm-v0.1.21) - 2026-05-20
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-i3-activitywatch/CHANGELOG.md
+++ b/enwiro-bridge-i3-activitywatch/CHANGELOG.md
@@ -6,3 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-bridge-i3-activitywatch-v0.1.0...enwiro-bridge-i3-activitywatch-v0.1.1) - 2026-05-21
+
+### Fixed
+
+- fix failing tests ([#491](https://github.com/kantord/enwiro/pull/491))
+- *(deps)* update rust crate ureq to v3 ([#490](https://github.com/kantord/enwiro/pull/490))

--- a/enwiro-bridge-i3-activitywatch/Cargo.toml
+++ b/enwiro-bridge-i3-activitywatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-i3-activitywatch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "ActivityWatch bridge for enwiro: reports the focused i3 workspace's enwiro env as aw-server heartbeats"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.14...enwiro-bridge-rofi-v0.1.15) - 2026-05-21
+
+### Added
+
+- unify list commands ([#487](https://github.com/kantord/enwiro/pull/487))
+
 ## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.13...enwiro-bridge-rofi-v0.1.14) - 2026-05-20
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.37](https://github.com/kantord/enwiro/compare/enwiro-v0.3.36...enwiro-v0.3.37) - 2026-05-21
+
+### Added
+
+- unify list commands ([#487](https://github.com/kantord/enwiro/pull/487))
+
 ## [0.3.36](https://github.com/kantord/enwiro/compare/enwiro-v0.3.35...enwiro-v0.3.36) - 2026-05-20
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.36"
+version = "0.3.37"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.36 -> 0.3.37
* `enwiro-adapter-i3wm`: 0.1.21 -> 0.1.22
* `enwiro-bridge-i3-activitywatch`: 0.1.0 -> 0.1.1
* `enwiro-bridge-rofi`: 0.1.14 -> 0.1.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.37](https://github.com/kantord/enwiro/compare/enwiro-v0.3.36...enwiro-v0.3.37) - 2026-05-21

### Added

- unify list commands ([#487](https://github.com/kantord/enwiro/pull/487))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.21...enwiro-adapter-i3wm-v0.1.22) - 2026-05-21

### Added

- unify list commands ([#487](https://github.com/kantord/enwiro/pull/487))
</blockquote>

## `enwiro-bridge-i3-activitywatch`

<blockquote>

## [0.1.1](https://github.com/kantord/enwiro/compare/enwiro-bridge-i3-activitywatch-v0.1.0...enwiro-bridge-i3-activitywatch-v0.1.1) - 2026-05-21

### Fixed

- fix failing tests ([#491](https://github.com/kantord/enwiro/pull/491))
- *(deps)* update rust crate ureq to v3 ([#490](https://github.com/kantord/enwiro/pull/490))
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.14...enwiro-bridge-rofi-v0.1.15) - 2026-05-21

### Added

- unify list commands ([#487](https://github.com/kantord/enwiro/pull/487))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).