### PR TITLE
feat(daemon): unified listen-driven cookbook/adapter pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +784,7 @@ dependencies = [
  "filetime",
  "home",
  "libc",
+ "optative-process-pool",
  "serde",
  "serde_json",
  "signal-hook",
@@ -1470,6 +1477,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1603,20 @@ checksum = "3fb53743e23c7620cbbbf36e1c21945ea1d5f63bf67471aa5664b21cefacb731"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "optative-process-pool"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a09b47e8550455d704a60858993c08bdf1eed2d89345cccf4c6eacc257e872"
+dependencies = [
+ "nix",
+ "optative",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2013,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",

--- a/enwiro-cookbook-chezmoi/src/main.rs
+++ b/enwiro-cookbook-chezmoi/src/main.rs
@@ -1,16 +1,19 @@
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::{Context, bail};
 use clap::Parser;
-use enwiro_sdk::{CookbookMetadata, Recipe};
+use enwiro_sdk::{CookbookMetadata, CookbookPayload, Recipe};
 
 const RECIPE_NAME: &str = "chezmoi";
+const LISTEN_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Parser)]
 enum EnwiroCookbookChezmoi {
     ListRecipes(ListRecipesArgs),
     Cook(CookArgs),
     Metadata,
+    Listen,
 }
 
 #[derive(clap::Args)]
@@ -71,6 +74,11 @@ fn main() -> anyhow::Result<()> {
                 }
                 .to_json()
             );
+        }
+        EnwiroCookbookChezmoi::Listen => {
+            let _ = CookbookPayload::read_first_line_from_stdin()
+                .context("Could not read cookbook payload from stdin")?;
+            enwiro_sdk::listen::serve(LISTEN_POLL_INTERVAL, || vec![Recipe::new(RECIPE_NAME)]);
         }
     };
 

--- a/enwiro-cookbook-git/src/main.rs
+++ b/enwiro-cookbook-git/src/main.rs
@@ -1,10 +1,12 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::Context;
 use clap::Parser;
+use enwiro_sdk::listen::RecipeUpdate;
 use enwiro_sdk::{CookbookMetadata, CookbookPayload, Recipe};
 use git2::Repository;
 use serde_derive::{Deserialize, Serialize};
@@ -182,7 +184,10 @@ enum EnwiroCookbookGit {
     ListRecipes(ListRecipesArgs),
     Cook(CookArgs),
     Metadata,
+    Listen,
 }
+
+const LISTEN_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(clap::Args)]
 pub struct ListRecipesArgs {}
@@ -383,6 +388,35 @@ fn list_recipes(config: &ConfigurationValues) -> anyhow::Result<()> {
         println!("{}", recipe.to_jsonl());
     }
     Ok(())
+}
+
+fn collect_recipes(config: &ConfigurationValues) -> Vec<Recipe> {
+    let Ok(repos) = build_repository_hashmap(config) else {
+        return Vec::new();
+    };
+    build_sorted_recipes(&repos)
+        .into_iter()
+        .map(|(key, sort_order)| {
+            let mut recipe = Recipe::new(key);
+            recipe.sort_order = sort_order;
+            recipe
+        })
+        .collect()
+}
+
+fn listen(config: &ConfigurationValues) -> anyhow::Result<()> {
+    let mut last_payload: Option<String> = None;
+    loop {
+        let update = RecipeUpdate::Recipes {
+            data: collect_recipes(config),
+        };
+        let payload = update.to_jsonl();
+        if last_payload.as_deref() != Some(payload.as_str()) {
+            println!("{}", payload);
+            last_payload = Some(payload);
+        }
+        std::thread::sleep(LISTEN_POLL_INTERVAL);
+    }
 }
 
 /// Cooks a recipe. It returns the path to the already existing local
@@ -1225,6 +1259,13 @@ fn main() -> anyhow::Result<()> {
                 }
                 .to_json()
             );
+        }
+        EnwiroCookbookGit::Listen => {
+            let config_value = enwiro_sdk::config::load_user_config("cookbook-git")
+                .context("Could not load user-level cookbook-git config")?;
+            let config: ConfigurationValues = serde_json::from_value(config_value)
+                .context("Could not deserialize cookbook-git configuration")?;
+            listen(&config)?;
         }
     };
 

--- a/enwiro-cookbook-git/src/main.rs
+++ b/enwiro-cookbook-git/src/main.rs
@@ -6,7 +6,6 @@ use std::{
 
 use anyhow::Context;
 use clap::Parser;
-use enwiro_sdk::listen::RecipeUpdate;
 use enwiro_sdk::{CookbookMetadata, CookbookPayload, Recipe};
 use git2::Repository;
 use serde_derive::{Deserialize, Serialize};
@@ -402,21 +401,6 @@ fn collect_recipes(config: &ConfigurationValues) -> Vec<Recipe> {
             recipe
         })
         .collect()
-}
-
-fn listen(config: &ConfigurationValues) -> anyhow::Result<()> {
-    let mut last_payload: Option<String> = None;
-    loop {
-        let update = RecipeUpdate::Recipes {
-            data: collect_recipes(config),
-        };
-        let payload = update.to_jsonl();
-        if last_payload.as_deref() != Some(payload.as_str()) {
-            println!("{}", payload);
-            last_payload = Some(payload);
-        }
-        std::thread::sleep(LISTEN_POLL_INTERVAL);
-    }
 }
 
 /// Cooks a recipe. It returns the path to the already existing local
@@ -1265,7 +1249,7 @@ fn main() -> anyhow::Result<()> {
                 .context("Could not read cookbook payload from stdin")?;
             let config: ConfigurationValues = serde_json::from_value(payload.config)
                 .context("Could not deserialize cookbook-git configuration")?;
-            listen(&config)?;
+            enwiro_sdk::listen::serve(LISTEN_POLL_INTERVAL, || collect_recipes(&config));
         }
     };
 

--- a/enwiro-cookbook-git/src/main.rs
+++ b/enwiro-cookbook-git/src/main.rs
@@ -187,7 +187,7 @@ enum EnwiroCookbookGit {
     Listen,
 }
 
-const LISTEN_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const LISTEN_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(clap::Args)]
 pub struct ListRecipesArgs {}
@@ -1261,9 +1261,9 @@ fn main() -> anyhow::Result<()> {
             );
         }
         EnwiroCookbookGit::Listen => {
-            let config_value = enwiro_sdk::config::load_user_config("cookbook-git")
-                .context("Could not load user-level cookbook-git config")?;
-            let config: ConfigurationValues = serde_json::from_value(config_value)
+            let payload = CookbookPayload::read_first_line_from_stdin()
+                .context("Could not read cookbook payload from stdin")?;
+            let config: ConfigurationValues = serde_json::from_value(payload.config)
                 .context("Could not deserialize cookbook-git configuration")?;
             listen(&config)?;
         }

--- a/enwiro-cookbook-github/src/main.rs
+++ b/enwiro-cookbook-github/src/main.rs
@@ -1,11 +1,14 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::Context;
 use clap::Parser;
 use enwiro_sdk::{CookbookMetadata, CookbookPayload, Recipe};
 use serde_derive::{Deserialize, Serialize};
+
+const LISTEN_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ConfigurationValues {
@@ -48,6 +51,7 @@ enum EnwiroCookbookGithub {
     Cook(CookArgs),
     Gear(GearArgs),
     Metadata,
+    Listen,
 }
 
 #[derive(clap::Args)]
@@ -340,30 +344,42 @@ fn compute_sort_order(index: usize, total: usize) -> u32 {
     }
 }
 
-fn list_recipes() -> anyhow::Result<()> {
-    let repos = discover_github_repos()?;
+fn collect_recipes() -> Vec<Recipe> {
+    let Ok(repos) = discover_github_repos() else {
+        return Vec::new();
+    };
     let repo_names: Vec<String> = repos.iter().map(|r| r.repo.clone()).collect();
 
-    let prs = search_github(&repo_names, "is:pr is:open")?;
+    let prs = search_github(&repo_names, "is:pr is:open").unwrap_or_default();
     // Issues are scoped to `assignee:@me` so only actionable work appears,
     // unlike PRs which show all open PRs on configured repos.
-    let issues = search_github(&repo_names, "is:issue is:open assignee:@me")?;
+    let issues = search_github(&repo_names, "is:issue is:open assignee:@me").unwrap_or_default();
 
     let mut items: Vec<GithubItem> = prs.into_iter().chain(issues).collect();
     sort_items_by_date(&mut items);
 
     let total = items.len();
-    for (index, item) in items.iter().enumerate() {
-        let safe_title = item.title.replace(['\n', '\0', '\x1f'], " ");
-        let prefix = match &item.kind {
-            GithubItemKind::PullRequest { .. } => "[PR]",
-            GithubItemKind::Issue => "[issue]",
-        };
-        let mut recipe = Recipe::with_description(
-            format!("{}#{}", item.repo, item.number),
-            format!("{} {}", prefix, safe_title),
-        );
-        recipe.sort_order = compute_sort_order(index, total);
+    items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let safe_title = item.title.replace(['\n', '\0', '\x1f'], " ");
+            let prefix = match &item.kind {
+                GithubItemKind::PullRequest { .. } => "[PR]",
+                GithubItemKind::Issue => "[issue]",
+            };
+            let mut recipe = Recipe::with_description(
+                format!("{}#{}", item.repo, item.number),
+                format!("{} {}", prefix, safe_title),
+            );
+            recipe.sort_order = compute_sort_order(index, total);
+            recipe
+        })
+        .collect()
+}
+
+fn list_recipes() -> anyhow::Result<()> {
+    for recipe in collect_recipes() {
         println!("{}", recipe.to_jsonl());
     }
     Ok(())
@@ -1484,6 +1500,11 @@ fn main() -> anyhow::Result<()> {
                 }
                 .to_json()
             );
+        }
+        EnwiroCookbookGithub::Listen => {
+            let _ = CookbookPayload::read_first_line_from_stdin()
+                .context("Could not read cookbook payload from stdin")?;
+            enwiro_sdk::listen::serve(LISTEN_POLL_INTERVAL, collect_recipes);
         }
     };
 

--- a/enwiro-cookbook-obsidian/src/main.rs
+++ b/enwiro-cookbook-obsidian/src/main.rs
@@ -1,16 +1,18 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
-use enwiro_sdk::{CookbookMetadata, Recipe};
+use enwiro_sdk::{CookbookMetadata, CookbookPayload, Recipe};
 use serde::Deserialize;
 
 const RECIPE_PREFIX: &str = "obsidian#";
 const DEFAULT_PRIORITY: u32 = 40;
 const OBSIDIAN_BINARY: &str = "obsidian";
 const ZOTERO_BINARY: &str = "zotero";
+const LISTEN_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Deserialize)]
 struct ObsidianVaultEntry {
@@ -178,6 +180,7 @@ enum EnwiroCookbookObsidian {
     Cook(CookArgs),
     Gear(GearArgs),
     Metadata,
+    Listen,
 }
 
 #[derive(clap::Args)]
@@ -256,6 +259,15 @@ fn main() -> Result<()> {
                 }
                 .to_json()
             );
+        }
+        EnwiroCookbookObsidian::Listen => {
+            let _ = CookbookPayload::read_first_line_from_stdin()
+                .context("Could not read cookbook payload from stdin")?;
+            enwiro_sdk::listen::serve(LISTEN_POLL_INTERVAL, || {
+                read_obsidian_json()
+                    .and_then(|json| list_recipes_from_json(&json))
+                    .unwrap_or_default()
+            });
         }
     }
     Ok(())

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -16,6 +16,7 @@ dirs = "6"
 enwiro-sdk.workspace = true
 home.workspace = true
 libc = "0.2"
+optative-process-pool = "0.0.2"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1"
 signal-hook = "0.4"

--- a/enwiro-daemon/src/lib.rs
+++ b/enwiro-daemon/src/lib.rs
@@ -269,13 +269,20 @@ pub fn run(
         });
     }
 
-    for (key, err) in pool.reconcile(desired) {
+    for (key, err) in pool.reconcile(desired.clone()) {
         tracing::warn!(key = ?key, error = ?err, "Could not spawn listen subprocess");
     }
 
     tracing::info!(pid = std::process::id(), "Daemon started");
 
     loop {
+        // Reconcile each tick so the upstream pool can restart any
+        // listen subprocess that exited since the previous iteration
+        // (via `Lifecycle::reconcile_self`, which checks `try_wait`).
+        for (key, err) in pool.reconcile(desired.clone()) {
+            tracing::warn!(key = ?key, error = ?err, "Could not respawn listen subprocess");
+        }
+
         loop {
             match stream_rx.try_recv() {
                 Ok(item) => {
@@ -289,17 +296,21 @@ pub fn run(
                             let env_dir = workspaces_directory.join(&env_name);
                             on_workspace_switch(&env_dir, timestamp);
                         }
-                    } else if let Some(entry) = recipe_state.get_mut(&item.key.key)
-                        && let Ok(RecipeUpdate::Recipes { data }) =
-                            serde_json::from_str::<RecipeUpdate>(&item.line)
-                    {
-                        entry.recipes = data;
-                        let new_cache = build_cache_content(&recipe_state);
-                        if last_cache_content.as_deref() != Some(new_cache.as_str()) {
-                            if let Err(e) = write_cache_atomic(&dir, &new_cache) {
-                                tracing::error!(error = %e, "Failed to write cache");
+                    } else if let Some(entry) = recipe_state.get_mut(&item.key.key) {
+                        match serde_json::from_str::<RecipeUpdate>(&item.line) {
+                            Ok(RecipeUpdate::Recipes { data }) => {
+                                entry.recipes = data;
+                                let new_cache = build_cache_content(&recipe_state);
+                                if last_cache_content.as_deref() != Some(new_cache.as_str()) {
+                                    if let Err(e) = write_cache_atomic(&dir, &new_cache) {
+                                        tracing::error!(error = %e, "Failed to write cache");
+                                    }
+                                    last_cache_content = Some(new_cache);
+                                }
                             }
-                            last_cache_content = Some(new_cache);
+                            Err(e) => {
+                                tracing::debug!(cookbook = %item.key.key, error = %e, line = %item.line, "Could not parse RecipeUpdate from cookbook stdout");
+                            }
                         }
                     }
                 }

--- a/enwiro-daemon/src/lib.rs
+++ b/enwiro-daemon/src/lib.rs
@@ -21,7 +21,7 @@ use anyhow::Context;
 use std::collections::HashMap;
 
 use enwiro_sdk::client::{CachedRecipe, CookbookClient, CookbookTrait};
-use enwiro_sdk::cookbook::Recipe;
+use enwiro_sdk::cookbook::{CookbookPayload, Recipe};
 use enwiro_sdk::listen::RecipeUpdate;
 use enwiro_sdk::plugin::{PluginKind, get_plugins};
 use optative_process_pool::{ProcessIdentity, ProcessPool, ProcessSource, StreamItem, StreamKind};
@@ -220,35 +220,6 @@ pub(crate) fn build_cache_content(state: &HashMap<String, CookbookEntry>) -> Str
     output
 }
 
-/// Collect recipes from all cookbooks as JSON lines, sorted globally
-/// by (sort_order, cookbook priority, name).
-/// Errors in individual cookbooks are logged and skipped.
-#[cfg(test)]
-pub(crate) fn collect_all_recipes(cookbooks: &[Box<dyn CookbookTrait>]) -> String {
-    let mut state: HashMap<String, CookbookEntry> = HashMap::new();
-    for cookbook in cookbooks {
-        match cookbook.list_recipes() {
-            Ok(recipes) => {
-                state.insert(
-                    cookbook.name().to_string(),
-                    CookbookEntry {
-                        priority: cookbook.priority(),
-                        recipes,
-                    },
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    cookbook = %cookbook.name(),
-                    error = %e,
-                    "Skipping cookbook due to error"
-                );
-            }
-        }
-    }
-    build_cache_content(&state)
-}
-
 /// Parse a JSONL workspace switch event line.
 /// Returns `Some((env_name, timestamp))` if the line is a valid `workspace_switch` event,
 /// or `None` for any other content (wrong type, missing fields, invalid JSON).
@@ -323,6 +294,8 @@ pub fn run(
         let name = plugin.name.clone();
         let executable = plugin.executable.clone();
         let client = CookbookClient::new_user_level_only(plugin);
+        let payload = CookbookPayload::new(client.config().clone());
+        let props = serde_json::to_value(&payload).ok();
         recipe_state.insert(
             name.clone(),
             CookbookEntry {
@@ -338,7 +311,7 @@ pub fn run(
             args: vec!["listen".to_string()],
             env: Default::default(),
             current_dir: None,
-            props: None,
+            props,
         });
     }
 
@@ -425,7 +398,6 @@ pub fn run(
 mod tests {
     use super::*;
     use enwiro_sdk::client::CachedRecipe;
-    use enwiro_sdk::test_helpers::{FailingCookbook, FakeCookbook};
 
     fn parse_cached_lines(output: &str) -> Vec<CachedRecipe> {
         output
@@ -435,16 +407,28 @@ mod tests {
             .collect()
     }
 
+    fn entry(priority: u32, recipes: Vec<Recipe>) -> CookbookEntry {
+        CookbookEntry { priority, recipes }
+    }
+
+    fn recipe_with_desc(name: &str, description: Option<&str>) -> Recipe {
+        match description {
+            Some(d) => Recipe::with_description(name, d),
+            None => Recipe::new(name),
+        }
+    }
+
     #[test]
-    fn test_collect_all_recipes_includes_description() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> =
-            vec![Box::new(FakeCookbook::new_with_descriptions(
-                "github",
-                vec![("owner/repo#42", Some("Fix auth bug"))],
-                vec![],
-            ))];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_includes_description() {
+        let mut state = HashMap::new();
+        state.insert(
+            "github".to_string(),
+            entry(
+                30,
+                vec![recipe_with_desc("owner/repo#42", Some("Fix auth bug"))],
+            ),
+        );
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].cookbook, "github");
         assert_eq!(entries[0].name, "owner/repo#42");
@@ -452,49 +436,43 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_all_recipes_omits_description_when_none() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![Box::new(
-            FakeCookbook::new_with_descriptions("git", vec![("repo-a", None)], vec![]),
-        )];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_omits_description_when_none() {
+        let mut state = HashMap::new();
+        state.insert("git".to_string(), entry(10, vec![Recipe::new("repo-a")]));
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "repo-a");
         assert!(entries[0].description.is_none());
     }
 
     #[test]
-    fn test_collect_all_recipes_formats_output() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![Box::new(FakeCookbook::new(
-            "git",
-            vec!["repo-a", "repo-b"],
-            vec![],
-        ))];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_formats_output_as_jsonl() {
+        let mut state = HashMap::new();
+        state.insert(
+            "git".to_string(),
+            entry(10, vec![Recipe::new("repo-a"), Recipe::new("repo-b")]),
+        );
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].name, "repo-a");
         assert_eq!(entries[1].name, "repo-b");
     }
 
     #[test]
-    fn test_collect_all_recipes_multiple_cookbooks() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![
-            Box::new(FakeCookbook::new("git", vec!["repo-a"], vec![])),
-            Box::new(FakeCookbook::new("npm", vec!["pkg-x"], vec![])),
-        ];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_combines_multiple_cookbooks() {
+        let mut state = HashMap::new();
+        state.insert("git".to_string(), entry(10, vec![Recipe::new("repo-a")]));
+        state.insert("npm".to_string(), entry(20, vec![Recipe::new("pkg-x")]));
+        let entries = parse_cached_lines(&build_cache_content(&state));
         let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
         assert!(names.contains(&"repo-a"));
         assert!(names.contains(&"pkg-x"));
     }
 
     #[test]
-    fn test_collect_all_recipes_empty() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![];
-        let output = collect_all_recipes(&cookbooks);
-        assert_eq!(output, "");
+    fn build_cache_content_empty_state_produces_empty_string() {
+        let state: HashMap<String, CookbookEntry> = HashMap::new();
+        assert_eq!(build_cache_content(&state), "");
     }
 
     #[test]
@@ -630,13 +608,14 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_all_recipes_sorts_by_priority() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![
-            Box::new(FakeCookbook::new("github", vec!["repo#42"], vec![]).with_priority(30)),
-            Box::new(FakeCookbook::new("git", vec!["my-repo"], vec![]).with_priority(10)),
-        ];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_sorts_by_priority() {
+        let mut state = HashMap::new();
+        state.insert(
+            "github".to_string(),
+            entry(30, vec![Recipe::new("repo#42")]),
+        );
+        state.insert("git".to_string(), entry(10, vec![Recipe::new("my-repo")]));
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(
             entries[0].cookbook, "git",
             "Higher priority (lower number) should come first"
@@ -647,13 +626,11 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_all_recipes_sorts_by_name_on_priority_tie() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![
-            Box::new(FakeCookbook::new("npm", vec!["pkg-x"], vec![]).with_priority(20)),
-            Box::new(FakeCookbook::new("git", vec!["repo-a"], vec![]).with_priority(20)),
-        ];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_sorts_by_name_on_priority_tie() {
+        let mut state = HashMap::new();
+        state.insert("npm".to_string(), entry(20, vec![Recipe::new("pkg-x")]));
+        state.insert("git".to_string(), entry(20, vec![Recipe::new("repo-a")]));
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(
             entries[0].name, "pkg-x",
             "Same sort_order and priority should tie-break by recipe name"
@@ -664,36 +641,18 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_all_recipes_skips_failing_cookbook() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![
-            Box::new(FailingCookbook {
-                cookbook_name: "broken".into(),
-            }),
-            Box::new(FakeCookbook::new("git", vec!["repo-a"], vec![])),
-        ];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].cookbook, "git");
-        assert_eq!(entries[0].name, "repo-a");
-    }
+    fn build_cache_content_sorts_globally_by_sort_order() {
+        let mut git_recipes = vec![Recipe::new("git-repo-a"), Recipe::new("git-repo-b")];
+        git_recipes[0].sort_order = 0;
+        git_recipes[1].sort_order = 50;
+        let mut gh_recipes = vec![Recipe::new("gh-issue-1"), Recipe::new("gh-issue-2")];
+        gh_recipes[0].sort_order = 0;
+        gh_recipes[1].sort_order = 50;
 
-    #[test]
-    fn test_collect_all_recipes_sorts_globally_by_sort_order() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![
-            Box::new(
-                FakeCookbook::new("git", vec!["git-repo-a", "git-repo-b"], vec![])
-                    .with_priority(10)
-                    .with_sort_orders(vec![0, 50]),
-            ),
-            Box::new(
-                FakeCookbook::new("github", vec!["gh-issue-1", "gh-issue-2"], vec![])
-                    .with_priority(30)
-                    .with_sort_orders(vec![0, 50]),
-            ),
-        ];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+        let mut state = HashMap::new();
+        state.insert("git".to_string(), entry(10, git_recipes));
+        state.insert("github".to_string(), entry(30, gh_recipes));
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(entries.len(), 4);
         assert_eq!(entries[0].name, "git-repo-a");
         assert_eq!(entries[0].sort_order, 0);
@@ -798,21 +757,16 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_all_recipes_interleaves_cookbooks_by_sort_order() {
-        let cookbooks: Vec<Box<dyn CookbookTrait>> = vec![
-            Box::new(
-                FakeCookbook::new("git", vec!["low-priority-branch"], vec![])
-                    .with_priority(10)
-                    .with_sort_orders(vec![80]),
-            ),
-            Box::new(
-                FakeCookbook::new("github", vec!["hot-issue"], vec![])
-                    .with_priority(30)
-                    .with_sort_orders(vec![0]),
-            ),
-        ];
-        let output = collect_all_recipes(&cookbooks);
-        let entries = parse_cached_lines(&output);
+    fn build_cache_content_interleaves_cookbooks_by_sort_order() {
+        let mut git_recipe = Recipe::new("low-priority-branch");
+        git_recipe.sort_order = 80;
+        let mut gh_recipe = Recipe::new("hot-issue");
+        gh_recipe.sort_order = 0;
+
+        let mut state = HashMap::new();
+        state.insert("git".to_string(), entry(10, vec![git_recipe]));
+        state.insert("github".to_string(), entry(30, vec![gh_recipe]));
+        let entries = parse_cached_lines(&build_cache_content(&state));
         assert_eq!(entries.len(), 2);
         assert_eq!(
             entries[0].name, "hot-issue",

--- a/enwiro-daemon/src/lib.rs
+++ b/enwiro-daemon/src/lib.rs
@@ -18,9 +18,26 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
 
+use std::collections::HashMap;
+
 use enwiro_sdk::client::{CachedRecipe, CookbookClient, CookbookTrait};
+use enwiro_sdk::cookbook::Recipe;
+use enwiro_sdk::listen::RecipeUpdate;
 use enwiro_sdk::plugin::{PluginKind, get_plugins};
 use optative_process_pool::{ProcessIdentity, ProcessPool, ProcessSource, StreamItem, StreamKind};
+
+/// Cookbook names whose recipe updates arrive via the unified
+/// `optative-process-pool` `listen` channel rather than the legacy
+/// periodic poll. Grows as each cookbook gains a `listen` subcommand.
+const LISTEN_DRIVEN_COOKBOOKS: &[&str] = &["git"];
+
+/// Per-cookbook state assembled from either the listen-stdout path
+/// or the legacy periodic poll. The cache content is rebuilt from
+/// this map on every change.
+struct CookbookEntry {
+    priority: u32,
+    recipes: Vec<Recipe>,
+}
 
 /// Returns the directory for daemon runtime files (PID, cache, heartbeat).
 /// Prefers $XDG_RUNTIME_DIR/enwiro, falls back to $XDG_CACHE_HOME/enwiro/run.
@@ -166,35 +183,22 @@ struct SortableCachedRecipe {
     priority: u32,
 }
 
-/// Collect recipes from all cookbooks as JSON lines, sorted globally
-/// by (sort_order, cookbook priority, name).
-/// Errors in individual cookbooks are logged and skipped.
-pub(crate) fn collect_all_recipes(cookbooks: &[Box<dyn CookbookTrait>]) -> String {
+/// Serialize a per-cookbook recipe state map into the cache file's
+/// JSON-lines format, sorted globally by (sort_order, cookbook priority, name).
+pub(crate) fn build_cache_content(state: &HashMap<String, CookbookEntry>) -> String {
     let mut all_recipes: Vec<SortableCachedRecipe> = Vec::new();
-
-    for cookbook in cookbooks {
-        match cookbook.list_recipes() {
-            Ok(recipes) => {
-                for recipe in recipes {
-                    all_recipes.push(SortableCachedRecipe {
-                        cached: CachedRecipe {
-                            cookbook: cookbook.name().to_string(),
-                            name: recipe.name,
-                            description: recipe.description,
-                            sort_order: recipe.sort_order,
-                            scores: None,
-                        },
-                        priority: cookbook.priority(),
-                    });
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    cookbook = %cookbook.name(),
-                    error = %e,
-                    "Skipping cookbook due to error"
-                );
-            }
+    for (cookbook_name, entry) in state {
+        for recipe in &entry.recipes {
+            all_recipes.push(SortableCachedRecipe {
+                cached: CachedRecipe {
+                    cookbook: cookbook_name.clone(),
+                    name: recipe.name.clone(),
+                    description: recipe.description.clone(),
+                    sort_order: recipe.sort_order,
+                    scores: None,
+                },
+                priority: entry.priority,
+            });
         }
     }
 
@@ -214,6 +218,35 @@ pub(crate) fn collect_all_recipes(cookbooks: &[Box<dyn CookbookTrait>]) -> Strin
         }
     }
     output
+}
+
+/// Collect recipes from all cookbooks as JSON lines, sorted globally
+/// by (sort_order, cookbook priority, name).
+/// Errors in individual cookbooks are logged and skipped.
+#[cfg(test)]
+pub(crate) fn collect_all_recipes(cookbooks: &[Box<dyn CookbookTrait>]) -> String {
+    let mut state: HashMap<String, CookbookEntry> = HashMap::new();
+    for cookbook in cookbooks {
+        match cookbook.list_recipes() {
+            Ok(recipes) => {
+                state.insert(
+                    cookbook.name().to_string(),
+                    CookbookEntry {
+                        priority: cookbook.priority(),
+                        recipes,
+                    },
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    cookbook = %cookbook.name(),
+                    error = %e,
+                    "Skipping cookbook due to error"
+                );
+            }
+        }
+    }
+    build_cache_content(&state)
 }
 
 /// Parse a JSONL workspace switch event line.
@@ -263,11 +296,12 @@ pub fn run(
 
     let (stream_tx, stream_rx) = std::sync::mpsc::channel::<StreamItem>();
     let mut pool = ProcessPool::new(stream_tx);
+    let mut recipe_state: HashMap<String, CookbookEntry> = HashMap::new();
+    let mut last_cache_content: Option<String> = None;
 
-    let adapter_desired: Vec<ProcessSource> = get_plugins(PluginKind::Adapter)
-        .into_iter()
-        .next()
-        .map(|plugin| ProcessSource {
+    let mut desired: Vec<ProcessSource> = Vec::new();
+    if let Some(plugin) = get_plugins(PluginKind::Adapter).into_iter().next() {
+        desired.push(ProcessSource {
             identity: ProcessIdentity {
                 bin: plugin.executable.clone(),
                 key: "adapter".to_string(),
@@ -280,12 +314,36 @@ pub fn run(
             env: Default::default(),
             current_dir: None,
             props: None,
-        })
-        .into_iter()
-        .collect();
+        });
+    }
+    for plugin in get_plugins(PluginKind::Cookbook) {
+        if !LISTEN_DRIVEN_COOKBOOKS.contains(&plugin.name.as_str()) {
+            continue;
+        }
+        let name = plugin.name.clone();
+        let executable = plugin.executable.clone();
+        let client = CookbookClient::new_user_level_only(plugin);
+        recipe_state.insert(
+            name.clone(),
+            CookbookEntry {
+                priority: client.priority(),
+                recipes: Vec::new(),
+            },
+        );
+        desired.push(ProcessSource {
+            identity: ProcessIdentity {
+                bin: executable,
+                key: name,
+            },
+            args: vec!["listen".to_string()],
+            env: Default::default(),
+            current_dir: None,
+            props: None,
+        });
+    }
 
-    for (key, err) in pool.reconcile(adapter_desired) {
-        tracing::warn!(key = ?key, error = ?err, "Could not spawn adapter listen subprocess");
+    for (key, err) in pool.reconcile(desired) {
+        tracing::warn!(key = ?key, error = ?err, "Could not spawn listen subprocess");
     }
 
     tracing::info!(pid = std::process::id(), "Daemon started");
@@ -297,11 +355,25 @@ pub fn run(
                     if item.stream != StreamKind::Stdout {
                         continue;
                     }
-                    if let Some((env_name, timestamp)) = parse_switch_event(&item.line)
-                        && !env_name.is_empty()
+                    if item.key.key == "adapter" {
+                        if let Some((env_name, timestamp)) = parse_switch_event(&item.line)
+                            && !env_name.is_empty()
+                        {
+                            let env_dir = workspaces_directory.join(&env_name);
+                            on_workspace_switch(&env_dir, timestamp);
+                        }
+                    } else if let Some(entry) = recipe_state.get_mut(&item.key.key)
+                        && let Ok(RecipeUpdate::Recipes { data }) =
+                            serde_json::from_str::<RecipeUpdate>(&item.line)
                     {
-                        let env_dir = workspaces_directory.join(&env_name);
-                        on_workspace_switch(&env_dir, timestamp);
+                        entry.recipes = data;
+                        let new_cache = build_cache_content(&recipe_state);
+                        if last_cache_content.as_deref() != Some(new_cache.as_str()) {
+                            if let Err(e) = write_cache_atomic(&dir, &new_cache) {
+                                tracing::error!(error = %e, "Failed to write cache");
+                            }
+                            last_cache_content = Some(new_cache);
+                        }
                     }
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => break,
@@ -310,15 +382,28 @@ pub fn run(
         }
 
         if should_refresh_cache(check_idle()) {
-            let plugins = get_plugins(PluginKind::Cookbook);
-            let cookbooks: Vec<Box<dyn CookbookTrait>> = plugins
-                .into_iter()
-                .map(|p| Box::new(CookbookClient::new_user_level_only(p)) as Box<dyn CookbookTrait>)
-                .collect();
-
-            let recipes = collect_all_recipes(&cookbooks);
-            if let Err(e) = write_cache_atomic(&dir, &recipes) {
-                tracing::error!(error = %e, "Failed to write cache");
+            for plugin in get_plugins(PluginKind::Cookbook) {
+                if LISTEN_DRIVEN_COOKBOOKS.contains(&plugin.name.as_str()) {
+                    continue;
+                }
+                let name = plugin.name.clone();
+                let client = CookbookClient::new_user_level_only(plugin);
+                let priority = client.priority();
+                match client.list_recipes() {
+                    Ok(recipes) => {
+                        recipe_state.insert(name, CookbookEntry { priority, recipes });
+                    }
+                    Err(e) => {
+                        tracing::warn!(cookbook = %name, error = %e, "Skipping cookbook due to error");
+                    }
+                }
+            }
+            let new_cache = build_cache_content(&recipe_state);
+            if last_cache_content.as_deref() != Some(new_cache.as_str()) {
+                if let Err(e) = write_cache_atomic(&dir, &new_cache) {
+                    tracing::error!(error = %e, "Failed to write cache");
+                }
+                last_cache_content = Some(new_cache);
             }
         }
 

--- a/enwiro-daemon/src/lib.rs
+++ b/enwiro-daemon/src/lib.rs
@@ -26,14 +26,8 @@ use enwiro_sdk::listen::RecipeUpdate;
 use enwiro_sdk::plugin::{PluginKind, get_plugins};
 use optative_process_pool::{ProcessIdentity, ProcessPool, ProcessSource, StreamItem, StreamKind};
 
-/// Cookbook names whose recipe updates arrive via the unified
-/// `optative-process-pool` `listen` channel rather than the legacy
-/// periodic poll. Grows as each cookbook gains a `listen` subcommand.
-const LISTEN_DRIVEN_COOKBOOKS: &[&str] = &["git"];
-
-/// Per-cookbook state assembled from either the listen-stdout path
-/// or the legacy periodic poll. The cache content is rebuilt from
-/// this map on every change.
+/// Per-cookbook state assembled from the listen-stdout stream. The
+/// cache content is rebuilt from this map on every change.
 struct CookbookEntry {
     priority: u32,
     recipes: Vec<Recipe>,
@@ -93,47 +87,14 @@ pub(crate) fn write_cache_atomic(runtime_dir: &Path, content: &str) -> anyhow::R
     Ok(())
 }
 
-/// Maximum age for a cache file to be considered valid (refresh interval + 30s buffer).
-const CACHE_MAX_AGE: Duration = Duration::from_secs(70); // 40s + 30s
-
-/// Read the cached recipes. Returns None if cache doesn't exist or is stale.
+/// Read the cached recipes. Returns None if the cache file doesn't exist.
 fn read_cached_recipes(runtime_dir: &Path) -> anyhow::Result<Option<String>> {
     let cache_path = runtime_dir.join("recipes.cache");
-    let metadata = match fs::metadata(&cache_path) {
-        Ok(m) => m,
-        Err(_) => return Ok(None),
-    };
-    if let Ok(modified) = metadata.modified() {
-        let age = SystemTime::now()
-            .duration_since(modified)
-            .unwrap_or(Duration::ZERO);
-        if age > CACHE_MAX_AGE {
-            tracing::debug!(age_secs = age.as_secs(), "Cache is stale, ignoring");
-            return Ok(None);
-        }
+    if !cache_path.exists() {
+        return Ok(None);
     }
     let content = fs::read_to_string(&cache_path).context("Could not read cache file")?;
     Ok(Some(content))
-}
-
-const USER_IDLE_THRESHOLD: Duration = Duration::from_secs(5400); // 90 minutes
-
-/// Returns true if the user has been idle longer than the threshold.
-/// When idle time is unavailable (e.g. Wayland without support), returns false
-/// so the daemon keeps running rather than dying unexpectedly.
-fn check_idle_with_timeout(get_idle: impl Fn() -> Option<Duration>, threshold: Duration) -> bool {
-    match get_idle() {
-        Some(idle) => idle > threshold,
-        None => false,
-    }
-}
-
-/// Returns true if the user has been idle longer than 90 minutes.
-pub(crate) fn check_idle() -> bool {
-    check_idle_with_timeout(
-        || system_idle_time::get_idle_time().ok(),
-        USER_IDLE_THRESHOLD,
-    )
 }
 
 /// Parse the PID file, returning (pid, optional binary mtime).
@@ -233,13 +194,9 @@ pub(crate) fn parse_switch_event(line: &str) -> Option<(String, i64)> {
     Some((env_name, timestamp))
 }
 
-const REFRESH_INTERVAL: Duration = Duration::from_secs(40);
-
-/// Returns true if the cache should be refreshed this cycle.
-/// The cache is refreshed only when the user is not idle.
-fn should_refresh_cache(is_idle: bool) -> bool {
-    !is_idle
-}
+/// How often the daemon's main loop wakes to check the termination flag
+/// and drain the cookbook/adapter stdout channel.
+const TICK_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Run the daemon. Blocks until SIGTERM/SIGINT/SIGHUP.
 ///
@@ -288,9 +245,6 @@ pub fn run(
         });
     }
     for plugin in get_plugins(PluginKind::Cookbook) {
-        if !LISTEN_DRIVEN_COOKBOOKS.contains(&plugin.name.as_str()) {
-            continue;
-        }
         let name = plugin.name.clone();
         let executable = plugin.executable.clone();
         let client = CookbookClient::new_user_level_only(plugin);
@@ -354,43 +308,13 @@ pub fn run(
             }
         }
 
-        if should_refresh_cache(check_idle()) {
-            for plugin in get_plugins(PluginKind::Cookbook) {
-                if LISTEN_DRIVEN_COOKBOOKS.contains(&plugin.name.as_str()) {
-                    continue;
-                }
-                let name = plugin.name.clone();
-                let client = CookbookClient::new_user_level_only(plugin);
-                let priority = client.priority();
-                match client.list_recipes() {
-                    Ok(recipes) => {
-                        recipe_state.insert(name, CookbookEntry { priority, recipes });
-                    }
-                    Err(e) => {
-                        tracing::warn!(cookbook = %name, error = %e, "Skipping cookbook due to error");
-                    }
-                }
-            }
-            let new_cache = build_cache_content(&recipe_state);
-            if last_cache_content.as_deref() != Some(new_cache.as_str()) {
-                if let Err(e) = write_cache_atomic(&dir, &new_cache) {
-                    tracing::error!(error = %e, "Failed to write cache");
-                }
-                last_cache_content = Some(new_cache);
-            }
+        if term.load(Ordering::Relaxed) {
+            tracing::info!("Received termination signal, exiting");
+            drop(pool);
+            remove_pid_file(&dir);
+            return Ok(());
         }
-
-        let mut elapsed = Duration::ZERO;
-        while elapsed < REFRESH_INTERVAL {
-            if term.load(Ordering::Relaxed) {
-                tracing::info!("Received termination signal, exiting");
-                drop(pool);
-                remove_pid_file(&dir);
-                return Ok(());
-            }
-            std::thread::sleep(Duration::from_secs(1));
-            elapsed += Duration::from_secs(1);
-        }
+        std::thread::sleep(TICK_INTERVAL);
     }
 }
 
@@ -531,32 +455,6 @@ mod tests {
     }
 
     #[test]
-    fn test_user_is_idle_when_idle_time_exceeds_threshold() {
-        let threshold = Duration::from_secs(5400);
-        let idle_time = Duration::from_secs(6000);
-        assert!(check_idle_with_timeout(|| Some(idle_time), threshold));
-    }
-
-    #[test]
-    fn test_user_is_not_idle_when_idle_time_below_threshold() {
-        let threshold = Duration::from_secs(5400);
-        let idle_time = Duration::from_secs(60);
-        assert!(!check_idle_with_timeout(|| Some(idle_time), threshold));
-    }
-
-    #[test]
-    fn test_user_is_not_idle_when_idle_time_equals_threshold() {
-        let threshold = Duration::from_secs(5400);
-        assert!(!check_idle_with_timeout(|| Some(threshold), threshold));
-    }
-
-    #[test]
-    fn test_user_is_not_idle_when_idle_time_unavailable() {
-        let threshold = Duration::from_secs(5400);
-        assert!(!check_idle_with_timeout(|| None, threshold));
-    }
-
-    #[test]
     fn test_write_and_read_cache() {
         let dir = tempfile::tempdir().unwrap();
         let content = r#"{"cookbook":"git","name":"my-repo"}
@@ -584,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_cache_returns_none_when_stale() {
+    fn test_read_cache_returns_content_regardless_of_mtime() {
         let dir = tempfile::tempdir().unwrap();
         write_cache_atomic(dir.path(), r#"{"cookbook":"git","name":"old-repo"}"#).unwrap();
         let past = filetime::FileTime::from_system_time(
@@ -592,9 +490,9 @@ mod tests {
         );
         filetime::set_file_mtime(dir.path().join("recipes.cache"), past).unwrap();
         let read = read_cached_recipes(dir.path()).unwrap();
-        assert_eq!(
-            read, None,
-            "Stale cache (older than refresh interval + 30s) should be treated as missing"
+        assert!(
+            read.is_some(),
+            "Cache freshness is no longer time-based — listen-driven cookbooks may not emit for arbitrary periods"
         );
     }
 
@@ -662,22 +560,6 @@ mod tests {
         assert_eq!(entries[2].sort_order, 50);
         assert_eq!(entries[3].name, "gh-issue-2");
         assert_eq!(entries[3].sort_order, 50);
-    }
-
-    #[test]
-    fn test_should_refresh_cache_when_not_idle() {
-        assert!(
-            should_refresh_cache(false),
-            "should_refresh_cache(false) must return true: active user means refresh is needed"
-        );
-    }
-
-    #[test]
-    fn test_should_not_refresh_cache_when_idle() {
-        assert!(
-            !should_refresh_cache(true),
-            "should_refresh_cache(true) must return false: idle user means skip the refresh"
-        );
     }
 
     #[test]

--- a/enwiro-daemon/src/lib.rs
+++ b/enwiro-daemon/src/lib.rs
@@ -20,6 +20,7 @@ use anyhow::Context;
 
 use enwiro_sdk::client::{CachedRecipe, CookbookClient, CookbookTrait};
 use enwiro_sdk::plugin::{PluginKind, get_plugins};
+use optative_process_pool::{ProcessIdentity, ProcessPool, ProcessSource, StreamItem, StreamKind};
 
 /// Returns the directory for daemon runtime files (PID, cache, heartbeat).
 /// Prefers $XDG_RUNTIME_DIR/enwiro, falls back to $XDG_CACHE_HOME/enwiro/run.
@@ -260,54 +261,43 @@ pub fn run(
     signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&term))?;
     signal_hook::flag::register(signal_hook::consts::SIGHUP, Arc::clone(&term))?;
 
-    let adapter_plugin = get_plugins(PluginKind::Adapter).into_iter().next();
-    let mut listen_child: Option<std::process::Child> = None;
-    if let Some(ref plugin) = adapter_plugin {
-        match std::process::Command::new(&plugin.executable)
-            .arg("listen")
-            .arg("--debounce-secs")
-            .arg("5")
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            Ok(child) => {
-                listen_child = Some(child);
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Could not spawn adapter listen subprocess");
-            }
-        }
-    }
+    let (stream_tx, stream_rx) = std::sync::mpsc::channel::<StreamItem>();
+    let mut pool = ProcessPool::new(stream_tx);
 
-    let (line_tx, line_rx) = std::sync::mpsc::channel::<String>();
-    if let Some(ref mut child) = listen_child
-        && let Some(stdout) = child.stdout.take()
-    {
-        let tx = line_tx.clone();
-        std::thread::spawn(move || {
-            use std::io::BufRead;
-            let reader = std::io::BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(l) => {
-                        if tx.send(l).is_err() {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
+    let adapter_desired: Vec<ProcessSource> = get_plugins(PluginKind::Adapter)
+        .into_iter()
+        .next()
+        .map(|plugin| ProcessSource {
+            identity: ProcessIdentity {
+                bin: plugin.executable.clone(),
+                key: "adapter".to_string(),
+            },
+            args: vec![
+                "listen".to_string(),
+                "--debounce-secs".to_string(),
+                "5".to_string(),
+            ],
+            env: Default::default(),
+            current_dir: None,
+            props: None,
+        })
+        .into_iter()
+        .collect();
+
+    for (key, err) in pool.reconcile(adapter_desired) {
+        tracing::warn!(key = ?key, error = ?err, "Could not spawn adapter listen subprocess");
     }
 
     tracing::info!(pid = std::process::id(), "Daemon started");
 
     loop {
         loop {
-            match line_rx.try_recv() {
-                Ok(line) => {
-                    if let Some((env_name, timestamp)) = parse_switch_event(&line)
+            match stream_rx.try_recv() {
+                Ok(item) => {
+                    if item.stream != StreamKind::Stdout {
+                        continue;
+                    }
+                    if let Some((env_name, timestamp)) = parse_switch_event(&item.line)
                         && !env_name.is_empty()
                     {
                         let env_dir = workspaces_directory.join(&env_name);
@@ -336,9 +326,7 @@ pub fn run(
         while elapsed < REFRESH_INTERVAL {
             if term.load(Ordering::Relaxed) {
                 tracing::info!("Received termination signal, exiting");
-                if let Some(mut child) = listen_child.take() {
-                    let _ = child.kill();
-                }
+                drop(pool);
                 remove_pid_file(&dir);
                 return Ok(());
             }

--- a/enwiro-sdk/src/client.rs
+++ b/enwiro-sdk/src/client.rs
@@ -92,6 +92,13 @@ impl CookbookClient {
         }
     }
 
+    /// The resolved cookbook config (typed as `serde_json::Value`).
+    /// Used by callers (e.g. the daemon) that need to forward the same
+    /// payload to a long-running `listen` subprocess over stdin.
+    pub fn config(&self) -> &serde_json::Value {
+        &self.config
+    }
+
     #[cfg(test)]
     fn with_metadata(plugin: Plugin, metadata: CookbookMetadata) -> Self {
         Self::with_metadata_and_config(

--- a/enwiro-sdk/src/cookbook.rs
+++ b/enwiro-sdk/src/cookbook.rs
@@ -81,6 +81,27 @@ impl CookbookPayload {
         }
         serde_json::from_str(&buf).context("Could not parse cookbook payload as JSON")
     }
+
+    /// Read one newline-delimited payload line from stdin. Used by
+    /// long-running subcommands (`listen`) whose stdin is kept open by
+    /// the daemon for subsequent events. Empty input is treated like
+    /// [`Self::read_from_stdin`].
+    pub fn read_first_line_from_stdin() -> anyhow::Result<Self> {
+        use std::io::BufRead;
+        let stdin = std::io::stdin();
+        let mut handle = stdin.lock();
+        let mut buf = String::new();
+        handle
+            .read_line(&mut buf)
+            .context("Could not read cookbook payload line from stdin")?;
+        if buf.trim().is_empty() {
+            return Ok(Self {
+                version: COOKBOOK_PAYLOAD_VERSION,
+                config: serde_json::Value::Object(Default::default()),
+            });
+        }
+        serde_json::from_str(buf.trim()).context("Could not parse cookbook payload as JSON")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/enwiro-sdk/src/lib.rs
+++ b/enwiro-sdk/src/lib.rs
@@ -11,6 +11,7 @@ pub mod cookbook;
 pub mod fs;
 pub mod garnish;
 pub mod gear;
+pub mod listen;
 pub mod logging;
 pub mod plugin;
 pub mod process;

--- a/enwiro-sdk/src/listen.rs
+++ b/enwiro-sdk/src/listen.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+use crate::cookbook::Recipe;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum RecipeUpdate {
+    Recipes { data: Vec<Recipe> },
+}
+
+impl RecipeUpdate {
+    pub fn to_jsonl(&self) -> String {
+        serde_json::to_string(self).expect("RecipeUpdate is always serializable")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recipes_roundtrip_through_json() {
+        let update = RecipeUpdate::Recipes {
+            data: vec![Recipe::new("foo"), Recipe::with_description("bar", "desc")],
+        };
+        let line = update.to_jsonl();
+        let parsed: RecipeUpdate = serde_json::from_str(&line).unwrap();
+        assert_eq!(update, parsed);
+    }
+
+    #[test]
+    fn recipes_serializes_with_type_tag() {
+        let update = RecipeUpdate::Recipes { data: vec![] };
+        let line = update.to_jsonl();
+        assert!(line.contains(r#""type":"recipes""#));
+    }
+}

--- a/enwiro-sdk/src/listen.rs
+++ b/enwiro-sdk/src/listen.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
 use crate::cookbook::Recipe;
@@ -11,6 +13,30 @@ pub enum RecipeUpdate {
 impl RecipeUpdate {
     pub fn to_jsonl(&self) -> String {
         serde_json::to_string(self).expect("RecipeUpdate is always serializable")
+    }
+}
+
+/// Long-running listen loop for cookbook binaries. Calls `build` to
+/// collect current recipes, emits `RecipeUpdate::Recipes` to stdout
+/// (skipping unchanged emissions), then sleeps `interval` before
+/// repeating. Cookbooks invoke this from their `listen` subcommand.
+///
+/// Never returns under normal operation; the daemon terminates the
+/// cookbook subprocess via the optative-process-pool's SIGTERM-then-
+/// SIGKILL teardown.
+pub fn serve<F>(interval: Duration, mut build: F) -> !
+where
+    F: FnMut() -> Vec<Recipe>,
+{
+    let mut last: Option<String> = None;
+    loop {
+        let update = RecipeUpdate::Recipes { data: build() };
+        let line = update.to_jsonl();
+        if last.as_deref() != Some(line.as_str()) {
+            println!("{}", line);
+            last = Some(line);
+        }
+        std::thread::sleep(interval);
     }
 }
 


### PR DESCRIPTION

## Closes / refs

- Closes #357 (originally framed as "add `refresh_interval()` to `CookbookTrait`"; the issue body is **out-of-date** relative to this implementation — will be edited in-place to reflect the pivot).
- Subsumes the adapter-spawn portion of #485 (bridges still need the `metadata`-declared `supports_listen` probe; deferred to #485's own PR).
