### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.38"
+version = "0.3.39"
 dependencies = [
  "anyhow",
  "assertables",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "clap",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.4.1" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.6" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.4.2" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.7" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.24...enwiro-adapter-i3wm-v0.1.25) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.23...enwiro-adapter-i3wm-v0.1.24) - 2026-05-23
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.8...enwiro-adapter-tmux-v0.1.9) - 2026-05-24
+
+### Added
+
+- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
+
 ## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.7...enwiro-adapter-tmux-v0.1.8) - 2026-05-23
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.16...enwiro-bridge-rofi-v0.1.17) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.15...enwiro-bridge-rofi-v0.1.16) - 2026-05-23
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.10...enwiro-cookbook-chezmoi-v0.1.11) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.9...enwiro-cookbook-chezmoi-v0.1.10) - 2026-05-23
 
 ### Added

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.17...enwiro-cookbook-git-v0.1.18) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.16...enwiro-cookbook-git-v0.1.17) - 2026-05-23
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.14...enwiro-cookbook-github-v0.1.15) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.13...enwiro-cookbook-github-v0.1.14) - 2026-05-23
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.7...enwiro-cookbook-obsidian-v0.1.8) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.6...enwiro-cookbook-obsidian-v0.1.7) - 2026-05-23
 
 ### Added

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.6...enwiro-daemon-v0.0.7) - 2026-05-24
+
+### Added
+
+- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
+- pilot IPC for daemon
+
 ## [0.0.6](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.5...enwiro-daemon-v0.0.6) - 2026-05-23
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.4...enwiro-garnish-just-v0.1.5) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.3...enwiro-garnish-just-v0.1.4) - 2026-05-23
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.4...enwiro-garnish-submodules-v0.1.5) - 2026-05-24
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.3...enwiro-garnish-submodules-v0.1.4) - 2026-05-23
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.4.1...enwiro-sdk-v0.4.2) - 2026-05-24
+
+### Added
+
+- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
+- pilot IPC for daemon
+
 ## [0.4.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.4.0...enwiro-sdk-v0.4.1) - 2026-05-23
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.39](https://github.com/kantord/enwiro/compare/enwiro-v0.3.38...enwiro-v0.3.39) - 2026-05-24
+
+### Added
+
+- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
+- pilot IPC for daemon
+
 ## [0.3.38](https://github.com/kantord/enwiro/compare/enwiro-v0.3.37...enwiro-v0.3.38) - 2026-05-23
 
 ### Other

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.38"
+version = "0.3.39"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `enwiro-daemon`: 0.0.6 -> 0.0.7 (✓ API compatible changes)
* `enwiro`: 0.3.38 -> 0.3.39
* `enwiro-adapter-tmux`: 0.1.8 -> 0.1.9
* `enwiro-adapter-i3wm`: 0.1.24 -> 0.1.25
* `enwiro-bridge-rofi`: 0.1.16 -> 0.1.17
* `enwiro-cookbook-chezmoi`: 0.1.10 -> 0.1.11
* `enwiro-cookbook-git`: 0.1.17 -> 0.1.18
* `enwiro-cookbook-github`: 0.1.14 -> 0.1.15
* `enwiro-cookbook-obsidian`: 0.1.7 -> 0.1.8
* `enwiro-garnish-just`: 0.1.4 -> 0.1.5
* `enwiro-garnish-submodules`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.4.2](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.4.1...enwiro-sdk-v0.4.2) - 2026-05-24

### Added

- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
- pilot IPC for daemon
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.7](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.6...enwiro-daemon-v0.0.7) - 2026-05-24

### Added

- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
- pilot IPC for daemon
</blockquote>

## `enwiro`

<blockquote>

## [0.3.39](https://github.com/kantord/enwiro/compare/enwiro-v0.3.38...enwiro-v0.3.39) - 2026-05-24

### Added

- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
- pilot IPC for daemon
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.8...enwiro-adapter-tmux-v0.1.9) - 2026-05-24

### Added

- add `enw info --json` ([#509](https://github.com/kantord/enwiro/pull/509))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.24...enwiro-adapter-i3wm-v0.1.25) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.16...enwiro-bridge-rofi-v0.1.17) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.10...enwiro-cookbook-chezmoi-v0.1.11) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.17...enwiro-cookbook-git-v0.1.18) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.14...enwiro-cookbook-github-v0.1.15) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.7...enwiro-cookbook-obsidian-v0.1.8) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.4...enwiro-garnish-just-v0.1.5) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.4...enwiro-garnish-submodules-v0.1.5) - 2026-05-24

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).