### PR TITLE
feat: add `enw info --json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 
@@ -679,6 +680,7 @@ dependencies = [
  "anyhow",
  "clap",
  "enwiro-sdk",
+ "serde_json",
  "tracing",
 ]
 
@@ -780,6 +782,7 @@ version = "0.0.6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "dirs",
  "enwiro-sdk",
  "filetime",

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -10,4 +10,5 @@ repository.workspace = true
 anyhow = "1"
 clap = { version = "4.5.4", features = ["derive"] }
 enwiro-sdk.workspace = true
+serde_json = "1"
 tracing.workspace = true

--- a/enwiro-adapter-tmux/src/main.rs
+++ b/enwiro-adapter-tmux/src/main.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use clap::Parser;
 use enwiro_sdk::adapter::RunPayload;
 use enwiro_sdk::process::ENWIRO_ENV_VAR;
@@ -8,6 +10,13 @@ enum EnwiroAdapterTmuxCli {
     GetActiveWorkspaceId,
     Activate(ActivateArgs),
     Run(RunArgs),
+    Listen(ListenArgs),
+}
+
+#[derive(clap::Args)]
+pub struct ListenArgs {
+    #[arg(long, default_value = "5")]
+    pub debounce_secs: u64,
 }
 
 #[derive(clap::Args)]
@@ -129,6 +138,9 @@ fn main() -> anyhow::Result<()> {
                 );
             }
         }
+        EnwiroAdapterTmuxCli::Listen(listen_args) => {
+            listen(listen_args.debounce_secs)?;
+        }
         EnwiroAdapterTmuxCli::Activate(activate_args) => {
             let name = &activate_args.name;
             validate_session_name(name)?;
@@ -149,6 +161,47 @@ fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+fn get_current_session() -> Option<String> {
+    let output = std::process::Command::new("tmux")
+        .args(["display-message", "-p", "#S"])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if name.is_empty() { None } else { Some(name) }
+    } else {
+        None
+    }
+}
+
+fn unix_timestamp() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+fn listen(debounce_secs: u64) -> anyhow::Result<()> {
+    let interval = Duration::from_secs(debounce_secs);
+    let mut last_session: Option<String> = None;
+
+    loop {
+        let current = get_current_session();
+        if current != last_session {
+            if let Some(ref name) = current {
+                let event = serde_json::json!({
+                    "type": "workspace_switch",
+                    "env_name": name,
+                    "timestamp": unix_timestamp(),
+                });
+                println!("{event}");
+            }
+            last_session = current;
+        }
+        std::thread::sleep(interval);
+    }
 }
 
 fn new_session_args(name: &str, shell: &str) -> Vec<String> {

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 dirs = "6"
 enwiro-sdk.workspace = true
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }

--- a/enwiro-daemon/src/lib.rs
+++ b/enwiro-daemon/src/lib.rs
@@ -19,6 +19,7 @@ use anyhow::Context;
 use tokio::signal::unix::{SignalKind, signal};
 
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use enwiro_sdk::client::{CachedRecipe, CookbookClient, CookbookTrait};
 use enwiro_sdk::cookbook::{CookbookPayload, Recipe};
@@ -277,7 +278,9 @@ pub async fn run(
         std::env::set_var(enwiro_sdk::rpc::SOCKET_ENV_VAR, rpc_socket_path.as_os_str());
     }
 
-    tokio::spawn(rpc::serve(rpc_socket_path.clone()));
+    let active_env: rpc::SharedActiveEnv = Arc::new(Mutex::new(None));
+    let active_env_writer = active_env.clone();
+    tokio::spawn(rpc::serve(rpc_socket_path.clone(), active_env));
 
     let (stream_tx, stream_rx) = std::sync::mpsc::channel::<StreamItem>();
     let mut pool = ProcessPool::new(stream_tx);
@@ -354,6 +357,8 @@ pub async fn run(
                         if let Some((env_name, timestamp)) = parse_switch_event(&item.line)
                             && !env_name.is_empty()
                         {
+                            *active_env_writer.lock().unwrap() =
+                                Some(rpc::ActiveEnvState { env_name: env_name.clone(), timestamp });
                             on_workspace_switch(&workspaces_directory.join(&env_name), timestamp);
                         }
                     } else if let Some(entry) = recipe_state.get_mut(&item.key.key) {

--- a/enwiro-daemon/src/rpc.rs
+++ b/enwiro-daemon/src/rpc.rs
@@ -19,11 +19,12 @@ use anyhow::Context;
 use async_trait::async_trait;
 use enwiro_sdk::rpc::{
     APPLICATION_ERROR_CODE, CALL_CHAIN_ENV_VAR, CYCLE_DETECTED_CODE, CookbookInvokeParams,
-    CookbookInvokeResult, EnwiroRpcServer,
+    CookbookInvokeResult, EnvCurrentResult, EnwiroRpcServer,
 };
 use futures_util::{SinkExt, StreamExt};
 use jsonrpsee::core::server::Methods;
 use jsonrpsee::types::{ErrorObjectOwned, error::ErrorCode};
+use std::sync::{Arc, Mutex};
 use tokio::net::{UnixListener, UnixStream};
 use tokio_util::codec::{Framed, LinesCodec};
 
@@ -42,11 +43,17 @@ const MAX_INVOKE_STDOUT_BYTES: u64 = 16 * 1024 * 1024;
 /// in error payloads; truncate aggressively.
 const MAX_INVOKE_STDERR_BYTES: u64 = 1024 * 1024;
 
-/// The struct that implements the RPC trait. Unit struct today — when
-/// Layer 2 (`env.current`) or Layer 3 (events) land, this gains a
-/// shared-state field.
-#[derive(Clone, Default)]
-struct DaemonRpc;
+pub struct ActiveEnvState {
+    pub env_name: String,
+    pub timestamp: i64,
+}
+
+pub type SharedActiveEnv = Arc<Mutex<Option<ActiveEnvState>>>;
+
+#[derive(Clone)]
+struct DaemonRpc {
+    active_env: SharedActiveEnv,
+}
 
 /// `APPLICATION_ERROR_CODE` constructor — every "cookbook X failed at Y"
 /// error in this module funnels through here so the wire shape stays
@@ -176,6 +183,18 @@ impl EnwiroRpcServer for DaemonRpc {
 
         Ok(CookbookInvokeResult { stdout })
     }
+
+    async fn env_current(&self) -> Result<EnvCurrentResult, ErrorObjectOwned> {
+        let state = self.active_env.lock().unwrap();
+        Ok(EnvCurrentResult {
+            env_name: state.as_ref().map(|s| s.env_name.clone()),
+            timestamp: state.as_ref().map(|s| {
+                chrono::DateTime::from_timestamp(s.timestamp, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_else(|| s.timestamp.to_string())
+            }),
+        })
+    }
 }
 
 /// Output of a single cookbook subprocess invocation; carries enough
@@ -277,7 +296,7 @@ async fn run_cookbook_subprocess(
 }
 
 /// Bind the unix socket, set perms to 0600, and run the accept loop.
-pub async fn serve(socket_path: PathBuf) -> anyhow::Result<()> {
+pub async fn serve(socket_path: PathBuf, active_env: SharedActiveEnv) -> anyhow::Result<()> {
     if let Some(parent) = socket_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create runtime dir {}", parent.display()))?;
@@ -291,14 +310,19 @@ pub async fn serve(socket_path: PathBuf) -> anyhow::Result<()> {
         std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("chmod 0600 {}", socket_path.display()))?;
     }
-    serve_listener(listener, socket_path).await
+    serve_listener(listener, socket_path, active_env).await
 }
 
 /// Run the accept loop against a pre-bound listener. Exposed so tests
 /// can own bind themselves (and surface bind errors directly) before
 /// signalling readiness.
-pub async fn serve_listener(listener: UnixListener, socket_path: PathBuf) -> anyhow::Result<()> {
-    let methods: Methods = DaemonRpc.into_rpc().into();
+pub async fn serve_listener(
+    listener: UnixListener,
+    socket_path: PathBuf,
+    active_env: SharedActiveEnv,
+) -> anyhow::Result<()> {
+    let rpc = DaemonRpc { active_env };
+    let methods: Methods = rpc.into_rpc().into();
     tracing::info!(path = %socket_path.display(), "rpc server listening");
 
     loop {

--- a/enwiro-daemon/tests/rpc_roundtrip.rs
+++ b/enwiro-daemon/tests/rpc_roundtrip.rs
@@ -6,6 +6,8 @@
 
 use std::os::unix::fs::PermissionsExt;
 
+use std::sync::{Arc, Mutex};
+
 use enwiro_daemon::rpc;
 use enwiro_sdk::rpc::{
     APPLICATION_ERROR_CODE, CYCLE_DETECTED_CODE, CookbookInvokeParams, EnwiroRpcClient, connect_at,
@@ -29,11 +31,12 @@ async fn spawn_server(tempdir: &TempDir) -> std::path::PathBuf {
     std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
         .expect("chmod 0600 rpc socket in test");
 
+    let active_env: Arc<Mutex<Option<rpc::ActiveEnvState>>> = Arc::new(Mutex::new(None));
     let (ready_tx, ready_rx) = oneshot::channel::<()>();
     let socket_path_clone = socket_path.clone();
     tokio::spawn(async move {
         let _ = ready_tx.send(());
-        let _ = rpc::serve_listener(listener, socket_path_clone).await;
+        let _ = rpc::serve_listener(listener, socket_path_clone, active_env).await;
     });
     ready_rx.await.expect("rpc server ready signal");
     socket_path
@@ -106,4 +109,41 @@ async fn cookbook_invoke_refuses_cycle_in_call_chain() {
         .unwrap_err();
 
     let _ = assert_call_error(err, CYCLE_DETECTED_CODE);
+}
+
+#[tokio::test]
+async fn env_current_returns_none_when_no_switch_seen() {
+    let (_tempdir, client) = setup().await;
+    let result = client.env_current().await.unwrap();
+    assert!(result.env_name.is_none());
+    assert!(result.timestamp.is_none());
+}
+
+#[tokio::test]
+async fn env_current_returns_state_when_set() {
+    let tempdir = TempDir::new().unwrap();
+    let socket_path = tempdir.path().join("rpc.sock");
+    let _ = std::fs::remove_file(&socket_path);
+    std::fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind");
+    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    let active_env: Arc<Mutex<Option<rpc::ActiveEnvState>>> =
+        Arc::new(Mutex::new(Some(rpc::ActiveEnvState {
+            env_name: "my-project".into(),
+            timestamp: 1700000000,
+        })));
+    let active_env_clone = active_env.clone();
+    let socket_path_clone = socket_path.clone();
+    let (ready_tx, ready_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = ready_tx.send(());
+        let _ = rpc::serve_listener(listener, socket_path_clone, active_env_clone).await;
+    });
+    ready_rx.await.unwrap();
+
+    let client = connect_at(&socket_path).await.unwrap();
+    let result = client.env_current().await.unwrap();
+    assert_eq!(result.env_name.as_deref(), Some("my-project"));
+    assert!(result.timestamp.is_some());
 }

--- a/enwiro-sdk/src/rpc.rs
+++ b/enwiro-sdk/src/rpc.rs
@@ -70,6 +70,15 @@ pub struct CookbookInvokeResult {
     pub stdout: String,
 }
 
+/// Result shape for `env.current`. The daemon returns whatever it last
+/// saw from the adapter's `workspace_switch` event stream; `None` fields
+/// mean "no switch event observed since daemon start".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvCurrentResult {
+    pub env_name: Option<String>,
+    pub timestamp: Option<String>,
+}
+
 /// Single source of truth for the client↔daemon RPC surface.
 #[jsonrpsee::proc_macros::rpc(server, client)]
 pub trait EnwiroRpc {
@@ -78,6 +87,9 @@ pub trait EnwiroRpc {
         &self,
         params: CookbookInvokeParams,
     ) -> Result<CookbookInvokeResult, jsonrpsee::types::ErrorObjectOwned>;
+
+    #[method(name = "env.current")]
+    async fn env_current(&self) -> Result<EnvCurrentResult, jsonrpsee::types::ErrorObjectOwned>;
 }
 
 pub mod client;

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -20,6 +20,7 @@ enwiro-sdk.workspace = true
 home.workspace = true
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1.37.0", default-features = false, features = ["rt"] }
 strum = { version = "0.28.0", features = ["derive"] }
 strum_macros = "0.28.0"
 notify-rust = "4"

--- a/enwiro/src/commands/env_info.rs
+++ b/enwiro/src/commands/env_info.rs
@@ -1,0 +1,75 @@
+use std::io::Write;
+
+use anyhow::Context;
+use clap::Args;
+use enwiro_sdk::process::ENWIRO_ENV_VAR;
+
+use crate::context::CommandContext;
+use crate::environments::Environment;
+
+#[derive(Args)]
+#[command(author, version, about = "Show information about an environment")]
+pub struct EnvInfoArgs {
+    /// Name of the environment to query. Defaults to the active environment.
+    pub name: Option<String>,
+
+    /// Output as JSON. Required; plain text output is not yet implemented.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(serde::Serialize)]
+struct EnvInfoOutput {
+    r#type: Option<String>,
+    name: Option<String>,
+}
+
+fn resolve_env_name_from_daemon() -> Option<String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()?;
+    rt.block_on(async {
+        let client = enwiro_sdk::rpc::connect().await.ok()?;
+        let result = enwiro_sdk::rpc::EnwiroRpcClient::env_current(&client)
+            .await
+            .ok()?;
+        result.env_name
+    })
+}
+
+fn resolve_env_name() -> Option<String> {
+    if let Some(name) = resolve_env_name_from_daemon() {
+        return Some(name);
+    }
+    std::env::var(ENWIRO_ENV_VAR).ok().filter(|v| !v.is_empty())
+}
+
+fn classify_env<W: Write>(ctx: &CommandContext<W>, name: &str) -> Option<String> {
+    if Environment::get_one(&ctx.config.workspaces_directory, name).is_ok() {
+        return Some("environment".into());
+    }
+    if ctx.find_recipe_in_cache_by_name(name) {
+        return Some("recipe".into());
+    }
+    None
+}
+
+pub fn env_info<W: Write>(ctx: &mut CommandContext<W>, args: EnvInfoArgs) -> anyhow::Result<()> {
+    if !args.json {
+        anyhow::bail!("Plain text output is not yet implemented. Use --json to get JSON output.");
+    }
+
+    let env_name = args.name.or_else(resolve_env_name);
+    let env_type = env_name.as_deref().and_then(|name| classify_env(ctx, name));
+
+    let output = EnvInfoOutput {
+        r#type: env_type,
+        name: env_name,
+    };
+
+    let json = serde_json::to_string(&output).context("Failed to serialize output")?;
+    write!(ctx.writer, "{json}")?;
+
+    Ok(())
+}

--- a/enwiro/src/commands/mod.rs
+++ b/enwiro/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod activate;
 pub mod adapter;
+pub mod env_info;
 pub mod ls;
 pub mod prep;
 pub mod rm;

--- a/enwiro/src/context.rs
+++ b/enwiro/src/context.rs
@@ -92,9 +92,10 @@ impl<W: Write> CommandContext<W> {
         Ok(env)
     }
 
-    /// Look up a recipe in the daemon cache.
-    /// Returns `Some((cookbook, description))` if the cache contains the recipe,
-    /// `None` for any miss (cache absent, stale, or recipe not listed).
+    pub fn find_recipe_in_cache_by_name(&self, recipe_name: &str) -> bool {
+        self.find_recipe_in_cache(recipe_name).is_some()
+    }
+
     fn find_recipe_in_cache(&self, recipe_name: &str) -> Option<(String, Option<String>)> {
         let cache = match &self.cache_dir {
             Some(dir) => enwiro_daemon::DaemonCache::with_runtime_dir(dir.clone()),

--- a/enwiro/src/main.rs
+++ b/enwiro/src/main.rs
@@ -9,6 +9,7 @@ mod usage_stats;
 use anyhow::Context;
 use clap::Parser;
 use commands::activate::{ActivateArgs, activate};
+use commands::env_info::{EnvInfoArgs, env_info};
 use commands::ls::{LsArgs, ls};
 use commands::prep::{PrepArgs, prep};
 use commands::rm::{RmArgs, rm};
@@ -26,6 +27,7 @@ use std::path::Path;
 #[derive(Parser)]
 enum EnwiroCli {
     Activate(ActivateArgs),
+    Info(EnvInfoArgs),
     Ls(LsArgs),
     Prep(PrepArgs),
     Rm(RmArgs),
@@ -81,6 +83,7 @@ fn main() -> anyhow::Result<()> {
 
     let result = match args {
         EnwiroCli::Activate(args) => activate(&mut context_object, args),
+        EnwiroCli::Info(args) => env_info(&mut context_object, args),
         EnwiroCli::Ls(args) => {
             let scope = args.scope();
             ls(&mut context_object, scope, args.json)


### PR DESCRIPTION
## Summary

- Add `enw info --json` subcommand that returns the current environment classified as `"environment"`, `"recipe"`, or `null`
- Implement `env.current` JSON-RPC method on the daemon (ADR-0002 Layer 2), tracking the last workspace switch event in memory
- Add `listen` subcommand to the tmux adapter (polling-based, emits `workspace_switch` events)

## Usage

```bash
# Current environment (auto-detected from daemon or ENWIRO_ENV)
enw info --json
# {"type":"environment","name":"my-project"}

# Specific environment
enw info --json other-project
# {"type":"recipe","name":"other-project"}

# No active environment
enw info --json
# {"type":null,"name":null}
```

## Related issues

- Closes #483
- Related to #432 (env-activation events) - this PR implements `env.current` RPC (Layer 2 of ADR-0002); #432 needs Layer 3 events (`events.subscribe`/`events.notify`)
- Related to #454 (tmux adapter docs) - tmux adapter now has `listen`, making it more feature-complete
- Related to #302 (live status tracking) - `env.current` RPC is a building block; #302 needs `status.get`

## Test plan

- [x] `env.current` RPC returns None when no switch event seen (unit test)
- [x] `env.current` RPC returns state when set (unit test)
- [x] All 84+ existing tests pass
- [x] Manual: `enw info --json` returns correct type/name for cooked environments
- [x] Manual: `enw info` (no --json) exits with error
- [x] Manual: `enw info --help` shows concise help text consistent with other commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)