### PR TITLE
feat: auto-mark status on cook and prep

### DIFF
--- a/enwiro/src/commands/prep.rs
+++ b/enwiro/src/commands/prep.rs
@@ -37,6 +37,7 @@ pub fn prep<W: Write>(context: &mut CommandContext<W>, args: PrepArgs) -> anyhow
     let env_dir = Path::new(&context.config.workspaces_directory).join(&env.name);
     if env_dir.is_dir() && !env_dir.is_symlink() {
         crate::usage_stats::record_prep_per_env(&env_dir);
+        crate::context::mark_via_daemon(&env.name, "ready");
     }
 
     context

--- a/enwiro/src/context.rs
+++ b/enwiro/src/context.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, anyhow};
+use enwiro_sdk::rpc::{EnvMarkParams, EnwiroRpcClient};
 
 use crate::{
     commands::adapter::{EnwiroAdapterExternal, EnwiroAdapterNone, EnwiroAdapterTrait},
@@ -89,6 +90,7 @@ impl<W: Write> CommandContext<W> {
         self.save_cook_metadata(&flat_name, &cookbook_name, name, description.as_deref());
         self.write_gear_if_present(cookbook.as_ref(), name, &flat_name);
         self.write_garnish_gear(&env_path, &flat_name, cfg);
+        mark_via_daemon(&flat_name, "active");
         Ok(env)
     }
 
@@ -226,6 +228,27 @@ impl<W: Write> CommandContext<W> {
     pub fn get_all_environments(&self) -> anyhow::Result<HashMap<String, Environment>> {
         Environment::get_all(&self.config.workspaces_directory)
     }
+}
+
+pub(crate) fn mark_via_daemon(env_name: &str, status: &str) {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        return;
+    };
+    let _ = rt.block_on(async {
+        let client = enwiro_sdk::rpc::connect().await.ok()?;
+        EnwiroRpcClient::env_mark(
+            &client,
+            EnvMarkParams {
+                env_name: env_name.to_string(),
+                status: status.to_string(),
+            },
+        )
+        .await
+        .ok()
+    });
 }
 
 /// Gate over `fire_autorun_on_cook` that respects `CookConfig::no_hooks`.


### PR DESCRIPTION
## Summary

- `enw cook` (via `cook_environment`) automatically marks the environment as `active`
- `enw prep` automatically marks the environment as `ready`
- Both calls are best-effort via the daemon RPC (`env.mark`) - if the daemon isn't running, the mark is silently skipped

Builds on #515 (manual `enw mark`). Part of #302 (live status tracking).

## Test plan

- [x] `cargo test` (full workspace, all passing)
- [ ] Manual: `enw prep <recipe>`, check `meta.json` for `"status": {"type": "cooked"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)