### PR TITLE
feat: improve enw run UX

### DIFF
--- a/enwiro-adapter-i3wm/src/main.rs
+++ b/enwiro-adapter-i3wm/src/main.rs
@@ -47,21 +47,46 @@ fn read_activate_payload() -> ActivatePayload {
 }
 
 fn build_run_shell_argv(command: &str, args: &[String]) -> String {
-    std::iter::once(command)
-        .chain(args.iter().map(String::as_str))
+    if args.is_empty() {
+        return command.to_string();
+    }
+    let quoted_args = args
+        .iter()
+        .map(String::as_str)
         .map(shell_quote)
         .collect::<Vec<_>>()
-        .join(" ")
+        .join(" ");
+    format!("{command} {quoted_args}")
+}
+
+fn user_shell() -> String {
+    std::env::var("SHELL").unwrap_or_else(|_| "sh".into())
+}
+
+/// Wrap the user's command so it runs in `$SHELL` and the terminal stays
+/// open on failure. The outer invocation is always POSIX `sh` so the
+/// error-handling syntax is portable; the user's command runs inside
+/// `$SHELL -c '...'` so they get their configured shell.
+fn wrap_with_error_feedback(user_cmd: &str, shell: &str) -> String {
+    let escaped = user_cmd.replace('\'', r"'\''");
+    format!(
+        "{shell} -c '{escaped}'; __enw_rc=$?; \
+         [ $__enw_rc -ne 0 ] && \
+         printf '\\n[enw] exited %d - press Enter\\n' $__enw_rc && \
+         read _; \
+         exit $__enw_rc"
+    )
 }
 
 /// Child is detached intentionally — enw exits before the terminal does.
 fn spawn_run_in_terminal(payload: &RunPayload) -> anyhow::Result<()> {
-    let quoted_argv = build_run_shell_argv(&payload.command, &payload.args);
+    let user_cmd = build_run_shell_argv(&payload.command, &payload.args);
+    let wrapped = wrap_with_error_feedback(&user_cmd, &user_shell());
     ProcessSpec::new("i3-sensible-terminal")
         .arg("-e")
         .arg("sh")
         .arg("-c")
-        .arg(&quoted_argv)
+        .arg(&wrapped)
         .into_command_in_env(&payload.env_name, std::path::Path::new(&payload.env_path))
         .spawn()
         .with_context(|| format!("Failed to spawn terminal for `{}`", payload.command))?;
@@ -987,6 +1012,72 @@ mod tests {
     #[case::escapes_single_quote("it's", r"'it'\''s'")]
     fn test_shell_quote_cases(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(shell_quote(input), expected);
+    }
+
+    #[test]
+    fn test_build_run_shell_argv_simple_command_no_args() {
+        assert_eq!(build_run_shell_argv("echo", &[]), "echo");
+    }
+
+    #[test]
+    fn test_build_run_shell_argv_simple_command_with_args() {
+        let args = vec!["hello world".to_string(), "foo".to_string()];
+        assert_eq!(
+            build_run_shell_argv("echo", &args),
+            "echo 'hello world' foo"
+        );
+    }
+
+    #[test]
+    fn test_build_run_shell_argv_shell_expression_no_args() {
+        let cmd = r#"bbox claude-code -- "please fix this bug""#;
+        assert_eq!(
+            build_run_shell_argv(cmd, &[]),
+            cmd,
+            "a full shell expression must pass through verbatim so sh -c can interpret it"
+        );
+    }
+
+    #[test]
+    fn test_wrap_with_error_feedback_contains_user_shell() {
+        let wrapped = wrap_with_error_feedback("echo hello", "/bin/zsh");
+        assert!(
+            wrapped.starts_with("/bin/zsh -c "),
+            "must invoke user's shell; got: {wrapped}"
+        );
+    }
+
+    #[test]
+    fn test_wrap_with_error_feedback_contains_error_handler() {
+        let wrapped = wrap_with_error_feedback("echo hello", "sh");
+        assert!(
+            wrapped.contains("__enw_rc=$?"),
+            "must capture exit code; got: {wrapped}"
+        );
+        assert!(
+            wrapped.contains("read _"),
+            "must wait for Enter on failure; got: {wrapped}"
+        );
+    }
+
+    #[test]
+    fn test_wrap_with_error_feedback_escapes_single_quotes() {
+        let wrapped = wrap_with_error_feedback("echo 'hello'", "bash");
+        assert!(
+            wrapped.contains(r"echo '\''hello'\''"),
+            "single quotes in user cmd must be escaped for outer sh; got: {wrapped}"
+        );
+    }
+
+    #[test]
+    fn test_user_shell_falls_back_to_sh() {
+        let prior = std::env::var("SHELL").ok();
+        unsafe { std::env::remove_var("SHELL") };
+        let result = user_shell();
+        if let Some(v) = prior {
+            unsafe { std::env::set_var("SHELL", v) };
+        }
+        assert_eq!(result, "sh");
     }
 
     /// `resolve_enw_binary` must produce an absolute path so the spawned

--- a/enwiro/src/context.rs
+++ b/enwiro/src/context.rs
@@ -24,6 +24,7 @@ pub struct CommandContext<W: Write> {
     pub notifier: Box<dyn Notifier>,
     pub cookbooks: Vec<Box<dyn CookbookTrait>>,
     pub cache_dir: Option<PathBuf>,
+    pub global_env: Option<String>,
 }
 
 impl<W: Write> CommandContext<W> {
@@ -57,6 +58,7 @@ impl<W: Write> CommandContext<W> {
             notifier,
             cookbooks,
             cache_dir: None,
+            global_env: None,
         })
     }
 
@@ -198,13 +200,15 @@ impl<W: Write> CommandContext<W> {
     }
 
     fn resolve_environment_name(&self, name: &Option<String>) -> anyhow::Result<String> {
-        match name {
-            Some(n) => Ok(n.clone()),
-            None => self
-                .adapter
-                .get_active_environment_name()
-                .context("Could not determine active environment"),
+        if let Some(n) = name {
+            return Ok(n.clone());
         }
+        if let Some(n) = &self.global_env {
+            return Ok(n.clone());
+        }
+        self.adapter
+            .get_active_environment_name()
+            .context("Could not determine active environment")
     }
 
     pub fn get_or_cook_environment(
@@ -212,11 +216,12 @@ impl<W: Write> CommandContext<W> {
         name: &Option<String>,
         cfg: &CookConfig,
     ) -> anyhow::Result<Environment> {
+        let explicitly_named = name.is_some() || self.global_env.is_some();
         let resolved = self.resolve_environment_name(name)?;
         let flat_name = resolved.replace('/', "-");
         match Environment::get_one(&self.config.workspaces_directory, &flat_name) {
             Ok(env) => Ok(env),
-            Err(_) if name.is_some() => self
+            Err(_) if explicitly_named => self
                 .cook_environment(&resolved, cfg)
                 .context("Could not cook environment"),
             Err(e) => Err(e),
@@ -740,6 +745,58 @@ mod tests {
         // "new-project" doesn't exist as an environment, so it should be cooked
         let env = context_object
             .get_or_cook_environment(&Some("new-project".to_string()), &CookConfig::default())
+            .unwrap();
+        assert_eq!(env.name, "new-project");
+    }
+
+    #[rstest]
+    fn test_global_env_used_when_positional_absent(
+        context_object: (tempfile::TempDir, FakeContext, AdapterLog, NotificationLog),
+    ) {
+        let (_temp_dir, mut context_object, _, _) = context_object;
+        context_object.create_mock_environment("from-flag");
+        context_object.global_env = Some("from-flag".to_string());
+
+        let env = context_object
+            .get_or_cook_environment(&None, &CookConfig::default())
+            .unwrap();
+        assert_eq!(env.name, "from-flag");
+    }
+
+    #[rstest]
+    fn test_positional_wins_over_global_env(
+        context_object: (tempfile::TempDir, FakeContext, AdapterLog, NotificationLog),
+    ) {
+        let (_temp_dir, mut context_object, _, _) = context_object;
+        context_object.create_mock_environment("positional");
+        context_object.create_mock_environment("from-flag");
+        context_object.global_env = Some("from-flag".to_string());
+
+        let env = context_object
+            .get_or_cook_environment(&Some("positional".to_string()), &CookConfig::default())
+            .unwrap();
+        assert_eq!(env.name, "positional");
+    }
+
+    #[rstest]
+    fn test_global_env_triggers_autocook(
+        context_object: (tempfile::TempDir, FakeContext, AdapterLog, NotificationLog),
+    ) {
+        let (temp_dir, mut context_object, _, _) = context_object;
+
+        let cooked_dir = temp_dir.path().join("cooked-target");
+        fs::create_dir(&cooked_dir).unwrap();
+
+        context_object.write_cache_entry("git", "new-project");
+        context_object.cookbooks = vec![Box::new(FakeCookbook::new(
+            "git",
+            vec!["new-project"],
+            vec![("new-project", cooked_dir.to_str().unwrap())],
+        ))];
+        context_object.global_env = Some("new-project".to_string());
+
+        let env = context_object
+            .get_or_cook_environment(&None, &CookConfig::default())
             .unwrap();
         assert_eq!(env.name, "new-project");
     }

--- a/enwiro/src/main.rs
+++ b/enwiro/src/main.rs
@@ -25,6 +25,15 @@ use std::io::Write;
 use std::path::Path;
 
 #[derive(Parser)]
+struct Cli {
+    #[arg(global = true, long)]
+    env: Option<String>,
+
+    #[command(subcommand)]
+    command: EnwiroCli,
+}
+
+#[derive(clap::Subcommand)]
 enum EnwiroCli {
     Activate(ActivateArgs),
     Info(EnvInfoArgs),
@@ -76,12 +85,13 @@ fn main() -> anyhow::Result<()> {
         return run_gear::dispatch(Path::new(&config.workspaces_directory), &argv[1..]);
     }
 
-    let args = EnwiroCli::parse();
+    let cli = Cli::parse();
     let mut writer = std::io::stdout();
     let mut context_object = CommandContext::new(config, &mut writer)?;
+    context_object.global_env = cli.env;
     ensure_can_run(&context_object)?;
 
-    let result = match args {
+    let result = match cli.command {
         EnwiroCli::Activate(args) => activate(&mut context_object, args),
         EnwiroCli::Info(args) => env_info(&mut context_object, args),
         EnwiroCli::Ls(args) => {

--- a/enwiro/src/test_utils.rs
+++ b/enwiro/src/test_utils.rs
@@ -169,6 +169,7 @@ pub mod test_utilities {
             notifier: Box::new(mock_notifier),
             cookbooks: vec![],
             cache_dir: Some(temp_dir.path().join("daemon")),
+            global_env: None,
         };
         (temp_dir, context, activated, notifications)
     }


### PR DESCRIPTION
## Summary

- Fix silent failure when `enw run` receives a shell expression as the command (e.g. `enw run 'bbox claude-code -- "fix this"'`) - the i3wm adapter was shell-quoting the entire command as a single token, making `sh -c` look for a nonexistent binary
- Add global `--env` flag available on all subcommands (`enw --env myproj run vim` or `enw run --env myproj vim`) as an alternative to the positional environment argument
- Use `$SHELL` instead of hardcoded `sh` in the i3wm adapter so commands run in the user's configured shell
- Keep terminal open on failure with exit code displayed (`[enw] exited N - press Enter`) instead of silently closing

Closes #520

Related: partially addresses #512 (CLI consistency via global `--env` flag)

## Test plan

- [x] `build_run_shell_argv` passes shell expressions through verbatim (3 tests)
- [x] `wrap_with_error_feedback` uses user's shell, contains error handler, escapes single quotes (3 tests)
- [x] `user_shell` falls back to `sh` when `$SHELL` unset (1 test)
- [x] `global_env` used as fallback when positional absent (1 test)
- [x] Positional wins over `global_env` (1 test)
- [x] `global_env` triggers autocook same as positional (1 test)
- [x] Full workspace test suite passes (550+ tests, 0 failures)
- [x] User live-tested: `enw run 'bbox claude-code -- "do you understand the issue"' headson#511` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)