### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.40"
+version = "0.3.41"
 dependencies = [
  "anyhow",
  "assertables",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "clap",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.5.0" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.8" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.5.1" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.9" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.26...enwiro-adapter-i3wm-v0.1.27) - 2026-05-25
+
+### Fixed
+
+- improve i3 stability ([#534](https://github.com/kantord/enwiro/pull/534))
+
 ## [0.1.26](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.25...enwiro-adapter-i3wm-v0.1.26) - 2026-05-25
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.10...enwiro-adapter-tmux-v0.1.11) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.9...enwiro-adapter-tmux-v0.1.10) - 2026-05-25
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.18...enwiro-bridge-rofi-v0.1.19) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.17...enwiro-bridge-rofi-v0.1.18) - 2026-05-25
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.12...enwiro-cookbook-chezmoi-v0.1.13) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.11...enwiro-cookbook-chezmoi-v0.1.12) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.19...enwiro-cookbook-git-v0.1.20) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.18...enwiro-cookbook-git-v0.1.19) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.16...enwiro-cookbook-github-v0.1.17) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.15...enwiro-cookbook-github-v0.1.16) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.9...enwiro-cookbook-obsidian-v0.1.10) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.8...enwiro-cookbook-obsidian-v0.1.9) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.8...enwiro-daemon-v0.0.9) - 2026-05-25
+
+### Fixed
+
+- *(deps)* update rust crate optative-process-pool to 0.0.3 ([#532](https://github.com/kantord/enwiro/pull/532))
+- validate plugin names ([#529](https://github.com/kantord/enwiro/pull/529))
+
 ## [0.0.8](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.7...enwiro-daemon-v0.0.8) - 2026-05-25
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.6...enwiro-garnish-just-v0.1.7) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.5...enwiro-garnish-just-v0.1.6) - 2026-05-25
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.6...enwiro-garnish-submodules-v0.1.7) - 2026-05-25
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.5...enwiro-garnish-submodules-v0.1.6) - 2026-05-25
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.5.0...enwiro-sdk-v0.5.1) - 2026-05-25
+
+### Fixed
+
+- validate plugin names ([#529](https://github.com/kantord/enwiro/pull/529))
+
 ## [0.5.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.4.2...enwiro-sdk-v0.5.0) - 2026-05-25
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.41](https://github.com/kantord/enwiro/compare/enwiro-v0.3.40...enwiro-v0.3.41) - 2026-05-25
+
+### Fixed
+
+- validate plugin names ([#529](https://github.com/kantord/enwiro/pull/529))
+
 ## [0.3.40](https://github.com/kantord/enwiro/compare/enwiro-v0.3.39...enwiro-v0.3.40) - 2026-05-25
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.40"
+version = "0.3.41"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `enwiro-daemon`: 0.0.8 -> 0.0.9 (✓ API compatible changes)
* `enwiro`: 0.3.40 -> 0.3.41
* `enwiro-adapter-i3wm`: 0.1.26 -> 0.1.27
* `enwiro-adapter-tmux`: 0.1.10 -> 0.1.11
* `enwiro-bridge-rofi`: 0.1.18 -> 0.1.19
* `enwiro-cookbook-chezmoi`: 0.1.12 -> 0.1.13
* `enwiro-cookbook-git`: 0.1.19 -> 0.1.20
* `enwiro-cookbook-github`: 0.1.16 -> 0.1.17
* `enwiro-cookbook-obsidian`: 0.1.9 -> 0.1.10
* `enwiro-garnish-just`: 0.1.6 -> 0.1.7
* `enwiro-garnish-submodules`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.5.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.5.0...enwiro-sdk-v0.5.1) - 2026-05-25

### Fixed

- validate plugin names ([#529](https://github.com/kantord/enwiro/pull/529))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.9](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.8...enwiro-daemon-v0.0.9) - 2026-05-25

### Fixed

- *(deps)* update rust crate optative-process-pool to 0.0.3 ([#532](https://github.com/kantord/enwiro/pull/532))
- validate plugin names ([#529](https://github.com/kantord/enwiro/pull/529))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.41](https://github.com/kantord/enwiro/compare/enwiro-v0.3.40...enwiro-v0.3.41) - 2026-05-25

### Fixed

- validate plugin names ([#529](https://github.com/kantord/enwiro/pull/529))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.26...enwiro-adapter-i3wm-v0.1.27) - 2026-05-25

### Fixed

- improve i3 stability ([#534](https://github.com/kantord/enwiro/pull/534))
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.10...enwiro-adapter-tmux-v0.1.11) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.18...enwiro-bridge-rofi-v0.1.19) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.12...enwiro-cookbook-chezmoi-v0.1.13) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.19...enwiro-cookbook-git-v0.1.20) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.16...enwiro-cookbook-github-v0.1.17) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.9...enwiro-cookbook-obsidian-v0.1.10) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.6...enwiro-garnish-just-v0.1.7) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.6...enwiro-garnish-submodules-v0.1.7) - 2026-05-25

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).