### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.42"
+version = "0.3.43"
 dependencies = [
  "anyhow",
  "assertables",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "clap",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.27...enwiro-adapter-i3wm-v0.1.28) - 2026-05-27
+
+### Fixed
+
+- further improve i3 stability ([#558](https://github.com/kantord/enwiro/pull/558))
+
+### Other
+
+- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
+
 ## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.26...enwiro-adapter-i3wm-v0.1.27) - 2026-05-25
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.43](https://github.com/kantord/enwiro/compare/enwiro-v0.3.42...enwiro-v0.3.43) - 2026-05-27
+
+### Fixed
+
+- further improve i3 stability ([#558](https://github.com/kantord/enwiro/pull/558))
+
 ## [0.3.42](https://github.com/kantord/enwiro/compare/enwiro-v0.3.41...enwiro-v0.3.42) - 2026-05-27
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.42"
+version = "0.3.43"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.42 -> 0.3.43
* `enwiro-adapter-i3wm`: 0.1.27 -> 0.1.28

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.43](https://github.com/kantord/enwiro/compare/enwiro-v0.3.42...enwiro-v0.3.43) - 2026-05-27

### Fixed

- further improve i3 stability ([#558](https://github.com/kantord/enwiro/pull/558))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.27...enwiro-adapter-i3wm-v0.1.28) - 2026-05-27

### Fixed

- further improve i3 stability ([#558](https://github.com/kantord/enwiro/pull/558))

### Other

- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).