### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.43"
+version = "0.3.44"
 dependencies = [
  "anyhow",
  "assertables",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "enwiro-sdk",

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.19...enwiro-bridge-rofi-v0.1.20) - 2026-05-27
+
+### Added
+
+- *(rofi)* improve status support ([#570](https://github.com/kantord/enwiro/pull/570))
+
+### Other
+
+- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
+
 ## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.18...enwiro-bridge-rofi-v0.1.19) - 2026-05-25
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.44](https://github.com/kantord/enwiro/compare/enwiro-v0.3.43...enwiro-v0.3.44) - 2026-05-27
+
+### Added
+
+- add `enw kanban` ([#567](https://github.com/kantord/enwiro/pull/567))
+- show notification when starting to cook environment ([#562](https://github.com/kantord/enwiro/pull/562))
+
+### Fixed
+
+- *(deps)* update rust crate crossterm to 0.29 ([#571](https://github.com/kantord/enwiro/pull/571))
+- *(deps)* update rust crate ratatui to 0.30 ([#572](https://github.com/kantord/enwiro/pull/572))
+
 ## [0.3.43](https://github.com/kantord/enwiro/compare/enwiro-v0.3.42...enwiro-v0.3.43) - 2026-05-27
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.43"
+version = "0.3.44"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.43 -> 0.3.44
* `enwiro-bridge-rofi`: 0.1.19 -> 0.1.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.44](https://github.com/kantord/enwiro/compare/enwiro-v0.3.43...enwiro-v0.3.44) - 2026-05-27

### Added

- add `enw kanban` ([#567](https://github.com/kantord/enwiro/pull/567))
- show notification when starting to cook environment ([#562](https://github.com/kantord/enwiro/pull/562))

### Fixed

- *(deps)* update rust crate crossterm to 0.29 ([#571](https://github.com/kantord/enwiro/pull/571))
- *(deps)* update rust crate ratatui to 0.30 ([#572](https://github.com/kantord/enwiro/pull/572))
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.19...enwiro-bridge-rofi-v0.1.20) - 2026-05-27

### Added

- *(rofi)* improve status support ([#570](https://github.com/kantord/enwiro/pull/570))

### Other

- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).