### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.45"
+version = "0.3.46"
 dependencies = [
  "anyhow",
  "assertables",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "clap",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "enwiro-sdk",

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.28...enwiro-adapter-i3wm-v0.1.29) - 2026-05-30
+
+### Fixed
+
+- further improve i3 stability ([#577](https://github.com/kantord/enwiro/pull/577))
+
+### Other
+
+- document adapters ([#563](https://github.com/kantord/enwiro/pull/563))
+
 ## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.27...enwiro-adapter-i3wm-v0.1.28) - 2026-05-27
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.20...enwiro-bridge-rofi-v0.1.21) - 2026-05-30
+
+### Fixed
+
+- rofi bridge does not cook recipes ([#584](https://github.com/kantord/enwiro/pull/584))
+
 ## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.19...enwiro-bridge-rofi-v0.1.20) - 2026-05-27
 
 ### Added

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.46](https://github.com/kantord/enwiro/compare/enwiro-v0.3.45...enwiro-v0.3.46) - 2026-05-30
+
+### Fixed
+
+- further improve i3 stability ([#577](https://github.com/kantord/enwiro/pull/577))
+
 ## [0.3.45](https://github.com/kantord/enwiro/compare/enwiro-v0.3.44...enwiro-v0.3.45) - 2026-05-27
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.45"
+version = "0.3.46"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro`: 0.3.45 -> 0.3.46
* `enwiro-adapter-i3wm`: 0.1.28 -> 0.1.29
* `enwiro-bridge-rofi`: 0.1.20 -> 0.1.21

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro`

<blockquote>

## [0.3.46](https://github.com/kantord/enwiro/compare/enwiro-v0.3.45...enwiro-v0.3.46) - 2026-05-30

### Fixed

- further improve i3 stability ([#577](https://github.com/kantord/enwiro/pull/577))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.29](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.28...enwiro-adapter-i3wm-v0.1.29) - 2026-05-30

### Fixed

- further improve i3 stability ([#577](https://github.com/kantord/enwiro/pull/577))

### Other

- document adapters ([#563](https://github.com/kantord/enwiro/pull/563))
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.20...enwiro-bridge-rofi-v0.1.21) - 2026-05-30

### Fixed

- rofi bridge does not cook recipes ([#584](https://github.com/kantord/enwiro/pull/584))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).