### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.46"
+version = "0.3.47"
 dependencies = [
  "anyhow",
  "assertables",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.5.1" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.9" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.6.0" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.10" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.29...enwiro-adapter-i3wm-v0.1.30) - 2026-06-03
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.29](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.28...enwiro-adapter-i3wm-v0.1.29) - 2026-05-30
 
 ### Fixed

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.11...enwiro-adapter-tmux-v0.1.12) - 2026-06-03
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.10...enwiro-adapter-tmux-v0.1.11) - 2026-05-25
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.21...enwiro-bridge-rofi-v0.1.22) - 2026-06-03
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.20...enwiro-bridge-rofi-v0.1.21) - 2026-05-30
 
 ### Fixed

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.13...enwiro-cookbook-chezmoi-v0.1.14) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
+### Other
+
+- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
+
 ## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.12...enwiro-cookbook-chezmoi-v0.1.13) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.20...enwiro-cookbook-git-v0.1.21) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
+### Other
+
+- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
+
 ## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.19...enwiro-cookbook-git-v0.1.20) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.17...enwiro-cookbook-github-v0.1.18) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.16...enwiro-cookbook-github-v0.1.17) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.10...enwiro-cookbook-obsidian-v0.1.11) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
+### Other
+
+- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.9...enwiro-cookbook-obsidian-v0.1.10) - 2026-05-25
 
 ### Other

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.9...enwiro-daemon-v0.0.10) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
 ## [0.0.9](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.8...enwiro-daemon-v0.0.9) - 2026-05-25
 
 ### Fixed

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.7...enwiro-garnish-just-v0.1.8) - 2026-06-03
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.6...enwiro-garnish-just-v0.1.7) - 2026-05-25
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.7...enwiro-garnish-submodules-v0.1.8) - 2026-06-03
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.6...enwiro-garnish-submodules-v0.1.7) - 2026-05-25
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.5.1...enwiro-sdk-v0.6.0) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
 ## [0.5.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.5.0...enwiro-sdk-v0.5.1) - 2026-05-25
 
 ### Fixed

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.47](https://github.com/kantord/enwiro/compare/enwiro-v0.3.46...enwiro-v0.3.47) - 2026-06-03
+
+### Added
+
+- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
+
 ## [0.3.46](https://github.com/kantord/enwiro/compare/enwiro-v0.3.45...enwiro-v0.3.46) - 2026-05-30
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.46"
+version = "0.3.47"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `enwiro-daemon`: 0.0.9 -> 0.0.10 (✓ API compatible changes)
* `enwiro`: 0.3.46 -> 0.3.47
* `enwiro-cookbook-chezmoi`: 0.1.13 -> 0.1.14
* `enwiro-cookbook-git`: 0.1.20 -> 0.1.21
* `enwiro-cookbook-github`: 0.1.17 -> 0.1.18
* `enwiro-cookbook-obsidian`: 0.1.10 -> 0.1.11
* `enwiro-adapter-i3wm`: 0.1.29 -> 0.1.30
* `enwiro-adapter-tmux`: 0.1.11 -> 0.1.12
* `enwiro-bridge-rofi`: 0.1.21 -> 0.1.22
* `enwiro-garnish-just`: 0.1.7 -> 0.1.8
* `enwiro-garnish-submodules`: 0.1.7 -> 0.1.8

### ⚠ `enwiro-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EnvMarkParams.source in /tmp/.tmpnAk3X9/enwiro/enwiro-sdk/src/rpc.rs:102

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type RecipeUpdate no longer derives Eq, in /tmp/.tmpnAk3X9/enwiro/enwiro-sdk/src/listen.rs:10

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant RecipeUpdate:StatusChanged in /tmp/.tmpnAk3X9/enwiro/enwiro-sdk/src/listen.rs:19
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.6.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.5.1...enwiro-sdk-v0.6.0) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.10](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.9...enwiro-daemon-v0.0.10) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.47](https://github.com/kantord/enwiro/compare/enwiro-v0.3.46...enwiro-v0.3.47) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.13...enwiro-cookbook-chezmoi-v0.1.14) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))

### Other

- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.20...enwiro-cookbook-git-v0.1.21) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))

### Other

- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.17...enwiro-cookbook-github-v0.1.18) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.10...enwiro-cookbook-obsidian-v0.1.11) - 2026-06-03

### Added

- automatically mark environments as done ([#589](https://github.com/kantord/enwiro/pull/589))

### Other

- add basic docs site ([#539](https://github.com/kantord/enwiro/pull/539))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.30](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.29...enwiro-adapter-i3wm-v0.1.30) - 2026-06-03

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.11...enwiro-adapter-tmux-v0.1.12) - 2026-06-03

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.21...enwiro-bridge-rofi-v0.1.22) - 2026-06-03

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.7...enwiro-garnish-just-v0.1.8) - 2026-06-03

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.8](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.7...enwiro-garnish-submodules-v0.1.8) - 2026-06-03

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).