### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.49"
+version = "0.3.50"
 dependencies = [
  "anyhow",
  "assertables",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2100,7 +2100,7 @@ checksum = "a5cb37f8743862c7fb7bffad204ce31c3e2e4cc6f25c7379e7e3077975f8635b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
 enwiro-sdk = { path = "enwiro-sdk", version = "0.7.0" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.11" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.12" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.11...enwiro-daemon-v0.0.12) - 2026-06-28
+
+### Fixed
+
+- *(deps)* update rust crate optative-process-pool to 0.0.4 ([#654](https://github.com/kantord/enwiro/pull/654))
+
 ## [0.0.11](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.10...enwiro-daemon-v0.0.11) - 2026-06-06
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.50](https://github.com/kantord/enwiro/compare/enwiro-v0.3.49...enwiro-v0.3.50) - 2026-06-28
+
+### Added
+
+- add experimental isolation feature (behind build flag) ([#639](https://github.com/kantord/enwiro/pull/639))
+
 ## [0.3.49](https://github.com/kantord/enwiro/compare/enwiro-v0.3.48...enwiro-v0.3.49) - 2026-06-10
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.49"
+version = "0.3.50"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-daemon`: 0.0.11 -> 0.0.12 (✓ API compatible changes)
* `enwiro`: 0.3.49 -> 0.3.50

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-daemon`

<blockquote>

## [0.0.12](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.11...enwiro-daemon-v0.0.12) - 2026-06-28

### Fixed

- *(deps)* update rust crate optative-process-pool to 0.0.4 ([#654](https://github.com/kantord/enwiro/pull/654))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.50](https://github.com/kantord/enwiro/compare/enwiro-v0.3.49...enwiro-v0.3.50) - 2026-06-28

### Added

- add experimental isolation feature (behind build flag) ([#639](https://github.com/kantord/enwiro/pull/639))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).