### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.50"
+version = "0.3.51"
 dependencies = [
  "anyhow",
  "assertables",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "clap",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.7.0" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.12" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.8.0" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.13" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.31...enwiro-adapter-i3wm-v0.1.32) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.31](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.30...enwiro-adapter-i3wm-v0.1.31) - 2026-06-06
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.13...enwiro-adapter-tmux-v0.1.14) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.12...enwiro-adapter-tmux-v0.1.13) - 2026-06-06
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.23...enwiro-bridge-rofi-v0.1.24) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.22...enwiro-bridge-rofi-v0.1.23) - 2026-06-06
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.15...enwiro-cookbook-chezmoi-v0.1.16) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.14...enwiro-cookbook-chezmoi-v0.1.15) - 2026-06-06
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.22...enwiro-cookbook-git-v0.1.23) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.21...enwiro-cookbook-git-v0.1.22) - 2026-06-06
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.19...enwiro-cookbook-github-v0.1.20) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.18...enwiro-cookbook-github-v0.1.19) - 2026-06-06
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.12...enwiro-cookbook-obsidian-v0.1.13) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.11...enwiro-cookbook-obsidian-v0.1.12) - 2026-06-06
 
 ### Added

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.12...enwiro-daemon-v0.0.13) - 2026-06-28
+
+### Added
+
+- add experimental container-based isolation (behind feature flag) ([#662](https://github.com/kantord/enwiro/pull/662))
+
 ## [0.0.12](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.11...enwiro-daemon-v0.0.12) - 2026-06-28
 
 ### Fixed

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.9...enwiro-garnish-just-v0.1.10) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.8...enwiro-garnish-just-v0.1.9) - 2026-06-06
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.9...enwiro-garnish-submodules-v0.1.10) - 2026-06-28
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.9](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.8...enwiro-garnish-submodules-v0.1.9) - 2026-06-06
 
 ### Fixed

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.7.0...enwiro-sdk-v0.8.0) - 2026-06-28
+
+### Added
+
+- add experimental container-based isolation (behind feature flag) ([#662](https://github.com/kantord/enwiro/pull/662))
+
 ## [0.7.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.6.0...enwiro-sdk-v0.7.0) - 2026-06-06
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.51](https://github.com/kantord/enwiro/compare/enwiro-v0.3.50...enwiro-v0.3.51) - 2026-06-28
+
+### Added
+
+- add experimental container-based isolation (behind feature flag) ([#662](https://github.com/kantord/enwiro/pull/662))
+
 ## [0.3.50](https://github.com/kantord/enwiro/compare/enwiro-v0.3.49...enwiro-v0.3.50) - 2026-06-28
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.50"
+version = "0.3.51"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `enwiro-daemon`: 0.0.12 -> 0.0.13 (✓ API compatible changes)
* `enwiro`: 0.3.50 -> 0.3.51
* `enwiro-adapter-i3wm`: 0.1.31 -> 0.1.32
* `enwiro-adapter-tmux`: 0.1.13 -> 0.1.14
* `enwiro-bridge-rofi`: 0.1.23 -> 0.1.24
* `enwiro-cookbook-chezmoi`: 0.1.15 -> 0.1.16
* `enwiro-cookbook-git`: 0.1.22 -> 0.1.23
* `enwiro-cookbook-github`: 0.1.19 -> 0.1.20
* `enwiro-cookbook-obsidian`: 0.1.12 -> 0.1.13
* `enwiro-garnish-just`: 0.1.9 -> 0.1.10
* `enwiro-garnish-submodules`: 0.1.9 -> 0.1.10

### ⚠ `enwiro-sdk` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method enwiro_sdk::rpc::EnwiroRpcServer::launch_resolve in file /tmp/.tmp37OCIi/enwiro/enwiro-sdk/src/rpc.rs:161
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.8.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.7.0...enwiro-sdk-v0.8.0) - 2026-06-28

### Added

- add experimental container-based isolation (behind feature flag) ([#662](https://github.com/kantord/enwiro/pull/662))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.13](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.12...enwiro-daemon-v0.0.13) - 2026-06-28

### Added

- add experimental container-based isolation (behind feature flag) ([#662](https://github.com/kantord/enwiro/pull/662))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.51](https://github.com/kantord/enwiro/compare/enwiro-v0.3.50...enwiro-v0.3.51) - 2026-06-28

### Added

- add experimental container-based isolation (behind feature flag) ([#662](https://github.com/kantord/enwiro/pull/662))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.32](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.31...enwiro-adapter-i3wm-v0.1.32) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.13...enwiro-adapter-tmux-v0.1.14) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.23...enwiro-bridge-rofi-v0.1.24) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.15...enwiro-cookbook-chezmoi-v0.1.16) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.22...enwiro-cookbook-git-v0.1.23) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.19...enwiro-cookbook-github-v0.1.20) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.12...enwiro-cookbook-obsidian-v0.1.13) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.9...enwiro-garnish-just-v0.1.10) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.9...enwiro-garnish-submodules-v0.1.10) - 2026-06-28

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).