### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.51"
+version = "0.3.52"
 dependencies = [
  "anyhow",
  "assertables",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
 enwiro-sdk = { path = "enwiro-sdk", version = "0.8.0" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.13" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.14" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.13...enwiro-daemon-v0.0.14) - 2026-07-02
+
+### Added
+
+- authenticate claude in experimental isolated containers ([#673](https://github.com/kantord/enwiro/pull/673))
+
 ## [0.0.13](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.12...enwiro-daemon-v0.0.13) - 2026-06-28
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.52](https://github.com/kantord/enwiro/compare/enwiro-v0.3.51...enwiro-v0.3.52) - 2026-07-02
+
+### Other
+
+- updated the following local packages: enwiro-daemon
+
 ## [0.3.51](https://github.com/kantord/enwiro/compare/enwiro-v0.3.50...enwiro-v0.3.51) - 2026-06-28
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.51"
+version = "0.3.52"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-daemon`: 0.0.13 -> 0.0.14 (✓ API compatible changes)
* `enwiro`: 0.3.51 -> 0.3.52

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-daemon`

<blockquote>

## [0.0.14](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.13...enwiro-daemon-v0.0.14) - 2026-07-02

### Added

- authenticate claude in experimental isolated containers ([#673](https://github.com/kantord/enwiro/pull/673))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.52](https://github.com/kantord/enwiro/compare/enwiro-v0.3.51...enwiro-v0.3.52) - 2026-07-02

### Other

- updated the following local packages: enwiro-daemon
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).