### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.52"
+version = "0.3.53"
 dependencies = [
  "anyhow",
  "assertables",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.8.0" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.14" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.8.1" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.15" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.32...enwiro-adapter-i3wm-v0.1.33) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.32](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.31...enwiro-adapter-i3wm-v0.1.32) - 2026-06-28
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.32"
+version = "0.1.33"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.14...enwiro-adapter-tmux-v0.1.15) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.13...enwiro-adapter-tmux-v0.1.14) - 2026-06-28
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.24...enwiro-bridge-rofi-v0.1.25) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.23...enwiro-bridge-rofi-v0.1.24) - 2026-06-28
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.16...enwiro-cookbook-chezmoi-v0.1.17) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.15...enwiro-cookbook-chezmoi-v0.1.16) - 2026-06-28
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.23...enwiro-cookbook-git-v0.1.24) - 2026-07-05
+
+### Fixed
+
+- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
+
 ## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.22...enwiro-cookbook-git-v0.1.23) - 2026-06-28
 
 ### Other

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.20...enwiro-cookbook-github-v0.1.21) - 2026-07-05
+
+### Fixed
+
+- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
+
 ## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.19...enwiro-cookbook-github-v0.1.20) - 2026-06-28
 
 ### Other

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.13...enwiro-cookbook-obsidian-v0.1.14) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.13](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.12...enwiro-cookbook-obsidian-v0.1.13) - 2026-06-28
 
 ### Other

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.14...enwiro-daemon-v0.0.15) - 2026-07-05
+
+### Added
+
+- harden claude-in-container auth and go Podman-only ([#683](https://github.com/kantord/enwiro/pull/683))
+- run isolated containers as the host user ([#682](https://github.com/kantord/enwiro/pull/682))
+- allow running claude from an isolated shell
+- bind claude auth proxy to teh container bridge ([#678](https://github.com/kantord/enwiro/pull/678))
+
+### Fixed
+
+- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
+- sanitize environment names before using them as OCI image tags ([#686](https://github.com/kantord/enwiro/pull/686))
+
 ## [0.0.14](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.13...enwiro-daemon-v0.0.14) - 2026-07-02
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.10...enwiro-garnish-just-v0.1.11) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.9...enwiro-garnish-just-v0.1.10) - 2026-06-28
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.10...enwiro-garnish-submodules-v0.1.11) - 2026-07-05
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.10](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.9...enwiro-garnish-submodules-v0.1.10) - 2026-06-28
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.8.0...enwiro-sdk-v0.8.1) - 2026-07-05
+
+### Fixed
+
+- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
+
 ## [0.8.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.7.0...enwiro-sdk-v0.8.0) - 2026-06-28
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.53](https://github.com/kantord/enwiro/compare/enwiro-v0.3.52...enwiro-v0.3.53) - 2026-07-05
+
+### Fixed
+
+- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
+
 ## [0.3.52](https://github.com/kantord/enwiro/compare/enwiro-v0.3.51...enwiro-v0.3.52) - 2026-07-02
 
 ### Other

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.52"
+version = "0.3.53"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `enwiro-daemon`: 0.0.14 -> 0.0.15 (✓ API compatible changes)
* `enwiro`: 0.3.52 -> 0.3.53
* `enwiro-cookbook-git`: 0.1.23 -> 0.1.24
* `enwiro-cookbook-github`: 0.1.20 -> 0.1.21
* `enwiro-adapter-i3wm`: 0.1.32 -> 0.1.33
* `enwiro-adapter-tmux`: 0.1.14 -> 0.1.15
* `enwiro-bridge-rofi`: 0.1.24 -> 0.1.25
* `enwiro-cookbook-chezmoi`: 0.1.16 -> 0.1.17
* `enwiro-cookbook-obsidian`: 0.1.13 -> 0.1.14
* `enwiro-garnish-just`: 0.1.10 -> 0.1.11
* `enwiro-garnish-submodules`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.8.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.8.0...enwiro-sdk-v0.8.1) - 2026-07-05

### Fixed

- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.15](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.14...enwiro-daemon-v0.0.15) - 2026-07-05

### Added

- harden claude-in-container auth and go Podman-only ([#683](https://github.com/kantord/enwiro/pull/683))
- run isolated containers as the host user ([#682](https://github.com/kantord/enwiro/pull/682))
- allow running claude from an isolated shell
- bind claude auth proxy to teh container bridge ([#678](https://github.com/kantord/enwiro/pull/678))

### Fixed

- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
- sanitize environment names before using them as OCI image tags ([#686](https://github.com/kantord/enwiro/pull/686))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.53](https://github.com/kantord/enwiro/compare/enwiro-v0.3.52...enwiro-v0.3.53) - 2026-07-05

### Fixed

- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.23...enwiro-cookbook-git-v0.1.24) - 2026-07-05

### Fixed

- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.20...enwiro-cookbook-github-v0.1.21) - 2026-07-05

### Fixed

- bind-mount a git worktree's main repo into the container ([#685](https://github.com/kantord/enwiro/pull/685))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.33](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.32...enwiro-adapter-i3wm-v0.1.33) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.14...enwiro-adapter-tmux-v0.1.15) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.24...enwiro-bridge-rofi-v0.1.25) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.16...enwiro-cookbook-chezmoi-v0.1.17) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.13...enwiro-cookbook-obsidian-v0.1.14) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.10...enwiro-garnish-just-v0.1.11) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.10...enwiro-garnish-submodules-v0.1.11) - 2026-07-05

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).