### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.53"
+version = "0.3.54"
 dependencies = [
  "anyhow",
  "assertables",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "clap",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.8.1" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.15" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.9.0" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.16" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.34](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.33...enwiro-adapter-i3wm-v0.1.34) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.33](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.32...enwiro-adapter-i3wm-v0.1.33) - 2026-07-05
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.33"
+version = "0.1.34"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.15...enwiro-adapter-tmux-v0.1.16) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.14...enwiro-adapter-tmux-v0.1.15) - 2026-07-05
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.26](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.25...enwiro-bridge-rofi-v0.1.26) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.24...enwiro-bridge-rofi-v0.1.25) - 2026-07-05
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.17...enwiro-cookbook-chezmoi-v0.1.18) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.16...enwiro-cookbook-chezmoi-v0.1.17) - 2026-07-05
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.24...enwiro-cookbook-git-v0.1.25) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.23...enwiro-cookbook-git-v0.1.24) - 2026-07-05
 
 ### Fixed

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.21...enwiro-cookbook-github-v0.1.22) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.20...enwiro-cookbook-github-v0.1.21) - 2026-07-05
 
 ### Fixed

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.14...enwiro-cookbook-obsidian-v0.1.15) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.13...enwiro-cookbook-obsidian-v0.1.14) - 2026-07-05
 
 ### Other

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.15...enwiro-daemon-v0.0.16) - 2026-07-07
+
+### Added
+
+- add experimental web gui ([#692](https://github.com/kantord/enwiro/pull/692))
+- add a global OCI-runtime override for microVM isolation via krun ([#694](https://github.com/kantord/enwiro/pull/694))
+- let envs declare a main_folder ([#688](https://github.com/kantord/enwiro/pull/688))
+
+### Fixed
+
+- mount a git worktree's real path alongside its env symlink ([#690](https://github.com/kantord/enwiro/pull/690))
+- *(deps)* update rust crate rand to 0.10 ([#684](https://github.com/kantord/enwiro/pull/684))
+
+### Other
+
+- *(deps)* pin dependencies ([#698](https://github.com/kantord/enwiro/pull/698))
+
 ## [0.0.15](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.14...enwiro-daemon-v0.0.15) - 2026-07-05
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.11...enwiro-garnish-just-v0.1.12) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.10...enwiro-garnish-just-v0.1.11) - 2026-07-05
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.11...enwiro-garnish-submodules-v0.1.12) - 2026-07-07
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.11](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.10...enwiro-garnish-submodules-v0.1.11) - 2026-07-05
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.8.1...enwiro-sdk-v0.9.0) - 2026-07-07
+
+### Added
+
+- add experimental web gui ([#692](https://github.com/kantord/enwiro/pull/692))
+
+### Other
+
+- *(deps)* pin dependencies ([#698](https://github.com/kantord/enwiro/pull/698))
+
 ## [0.8.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.8.0...enwiro-sdk-v0.8.1) - 2026-07-05
 
 ### Fixed

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.54](https://github.com/kantord/enwiro/compare/enwiro-v0.3.53...enwiro-v0.3.54) - 2026-07-07
+
+### Added
+
+- allow aliasing recipes ([#697](https://github.com/kantord/enwiro/pull/697))
+- add experimental web gui ([#692](https://github.com/kantord/enwiro/pull/692))
+- let envs declare a main_folder ([#688](https://github.com/kantord/enwiro/pull/688))
+
+### Other
+
+- *(deps)* pin dependencies ([#698](https://github.com/kantord/enwiro/pull/698))
+
 ## [0.3.53](https://github.com/kantord/enwiro/compare/enwiro-v0.3.52...enwiro-v0.3.53) - 2026-07-05
 
 ### Fixed

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.53"
+version = "0.3.54"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.8.1 -> 0.9.0 (⚠ API breaking changes)
* `enwiro-daemon`: 0.0.15 -> 0.0.16 (✓ API compatible changes)
* `enwiro`: 0.3.53 -> 0.3.54
* `enwiro-adapter-i3wm`: 0.1.33 -> 0.1.34
* `enwiro-adapter-tmux`: 0.1.15 -> 0.1.16
* `enwiro-bridge-rofi`: 0.1.25 -> 0.1.26
* `enwiro-cookbook-chezmoi`: 0.1.17 -> 0.1.18
* `enwiro-cookbook-git`: 0.1.24 -> 0.1.25
* `enwiro-cookbook-github`: 0.1.21 -> 0.1.22
* `enwiro-cookbook-obsidian`: 0.1.14 -> 0.1.15
* `enwiro-garnish-just`: 0.1.11 -> 0.1.12
* `enwiro-garnish-submodules`: 0.1.11 -> 0.1.12

### ⚠ `enwiro-sdk` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method enwiro_sdk::rpc::EnwiroRpcServer::env_list in file /tmp/.tmpBW17GB/enwiro/enwiro-sdk/src/rpc.rs:188
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.9.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.8.1...enwiro-sdk-v0.9.0) - 2026-07-07

### Added

- add experimental web gui ([#692](https://github.com/kantord/enwiro/pull/692))

### Other

- *(deps)* pin dependencies ([#698](https://github.com/kantord/enwiro/pull/698))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.16](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.15...enwiro-daemon-v0.0.16) - 2026-07-07

### Added

- add experimental web gui ([#692](https://github.com/kantord/enwiro/pull/692))
- add a global OCI-runtime override for microVM isolation via krun ([#694](https://github.com/kantord/enwiro/pull/694))
- let envs declare a main_folder ([#688](https://github.com/kantord/enwiro/pull/688))

### Fixed

- mount a git worktree's real path alongside its env symlink ([#690](https://github.com/kantord/enwiro/pull/690))
- *(deps)* update rust crate rand to 0.10 ([#684](https://github.com/kantord/enwiro/pull/684))

### Other

- *(deps)* pin dependencies ([#698](https://github.com/kantord/enwiro/pull/698))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.54](https://github.com/kantord/enwiro/compare/enwiro-v0.3.53...enwiro-v0.3.54) - 2026-07-07

### Added

- allow aliasing recipes ([#697](https://github.com/kantord/enwiro/pull/697))
- add experimental web gui ([#692](https://github.com/kantord/enwiro/pull/692))
- let envs declare a main_folder ([#688](https://github.com/kantord/enwiro/pull/688))

### Other

- *(deps)* pin dependencies ([#698](https://github.com/kantord/enwiro/pull/698))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.34](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.33...enwiro-adapter-i3wm-v0.1.34) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.15...enwiro-adapter-tmux-v0.1.16) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.26](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.25...enwiro-bridge-rofi-v0.1.26) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.17...enwiro-cookbook-chezmoi-v0.1.18) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.24...enwiro-cookbook-git-v0.1.25) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.21...enwiro-cookbook-github-v0.1.22) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.14...enwiro-cookbook-obsidian-v0.1.15) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.11...enwiro-garnish-just-v0.1.12) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.12](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.11...enwiro-garnish-submodules-v0.1.12) - 2026-07-07

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).