### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.56"
+version = "0.3.57"
 dependencies = [
  "anyhow",
  "assertables",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-activitywatch"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1009,7 +1009,7 @@ version = "0.1.3"
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-gui"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.10.1" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.18" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.10.2" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.19" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.37](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.36...enwiro-adapter-i3wm-v0.1.37) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.36](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.35...enwiro-adapter-i3wm-v0.1.36) - 2026-07-08
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.36"
+version = "0.1.37"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.18...enwiro-adapter-tmux-v0.1.19) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.17...enwiro-adapter-tmux-v0.1.18) - 2026-07-08
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-activitywatch/CHANGELOG.md
+++ b/enwiro-bridge-activitywatch/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.3...enwiro-bridge-activitywatch-v0.1.4) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.2...enwiro-bridge-activitywatch-v0.1.3) - 2026-07-08
 
 ### Other

--- a/enwiro-bridge-activitywatch/Cargo.toml
+++ b/enwiro-bridge-activitywatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-activitywatch"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "ActivityWatch bridge for enwiro: reports the active enwiro env as aw-server heartbeats"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.28...enwiro-bridge-rofi-v0.1.29) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.27...enwiro-bridge-rofi-v0.1.28) - 2026-07-08
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.20...enwiro-cookbook-chezmoi-v0.1.21) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.19...enwiro-cookbook-chezmoi-v0.1.20) - 2026-07-08
 
 ### Other

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.27...enwiro-cookbook-git-v0.1.28) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.26...enwiro-cookbook-git-v0.1.27) - 2026-07-08
 
 ### Other

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.24...enwiro-cookbook-github-v0.1.25) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.23...enwiro-cookbook-github-v0.1.24) - 2026-07-08
 
 ### Other

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.17...enwiro-cookbook-obsidian-v0.1.18) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.16...enwiro-cookbook-obsidian-v0.1.17) - 2026-07-08
 
 ### Other

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.19](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.18...enwiro-daemon-v0.0.19) - 2026-07-08
+
+### Fixed
+
+- spawn the configured listen adapter when multiple ones exist ([#718](https://github.com/kantord/enwiro/pull/718))
+
 ## [0.0.18](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.17...enwiro-daemon-v0.0.18) - 2026-07-08
 
 ### Other

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.14...enwiro-garnish-just-v0.1.15) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.13...enwiro-garnish-just-v0.1.14) - 2026-07-08
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.14...enwiro-garnish-submodules-v0.1.15) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.14](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.13...enwiro-garnish-submodules-v0.1.14) - 2026-07-08
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-gui/CHANGELOG.md
+++ b/enwiro-gui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.2...enwiro-gui-v0.1.3) - 2026-07-08
+
+### Other
+
+- updated the following local packages: enwiro-sdk, enwiro-daemon
+
 ## [0.1.2](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.1...enwiro-gui-v0.1.2) - 2026-07-08
 
 ### Other

--- a/enwiro-gui/Cargo.toml
+++ b/enwiro-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-gui"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Local web GUI for enwiro: a single binary that serves an embedded React SPA to the browser"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.1...enwiro-sdk-v0.10.2) - 2026-07-08
+
+### Fixed
+
+- spawn the configured listen adapter when multiple ones exist ([#718](https://github.com/kantord/enwiro/pull/718))
+
 ## [0.10.1](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.0...enwiro-sdk-v0.10.1) - 2026-07-08
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.57](https://github.com/kantord/enwiro/compare/enwiro-v0.3.56...enwiro-v0.3.57) - 2026-07-08
+
+### Fixed
+
+- spawn the configured listen adapter when multiple ones exist ([#718](https://github.com/kantord/enwiro/pull/718))
+
 ## [0.3.56](https://github.com/kantord/enwiro/compare/enwiro-v0.3.55...enwiro-v0.3.56) - 2026-07-08
 
 ### Other

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.56"
+version = "0.3.57"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `enwiro-daemon`: 0.0.18 -> 0.0.19 (✓ API compatible changes)
* `enwiro`: 0.3.56 -> 0.3.57
* `enwiro-gui`: 0.1.2 -> 0.1.3
* `enwiro-adapter-i3wm`: 0.1.36 -> 0.1.37
* `enwiro-adapter-tmux`: 0.1.18 -> 0.1.19
* `enwiro-bridge-activitywatch`: 0.1.3 -> 0.1.4
* `enwiro-bridge-rofi`: 0.1.28 -> 0.1.29
* `enwiro-cookbook-chezmoi`: 0.1.20 -> 0.1.21
* `enwiro-cookbook-git`: 0.1.27 -> 0.1.28
* `enwiro-cookbook-github`: 0.1.24 -> 0.1.25
* `enwiro-cookbook-obsidian`: 0.1.17 -> 0.1.18
* `enwiro-garnish-just`: 0.1.14 -> 0.1.15
* `enwiro-garnish-submodules`: 0.1.14 -> 0.1.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.10.2](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.1...enwiro-sdk-v0.10.2) - 2026-07-08

### Fixed

- spawn the configured listen adapter when multiple ones exist ([#718](https://github.com/kantord/enwiro/pull/718))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.19](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.18...enwiro-daemon-v0.0.19) - 2026-07-08

### Fixed

- spawn the configured listen adapter when multiple ones exist ([#718](https://github.com/kantord/enwiro/pull/718))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.57](https://github.com/kantord/enwiro/compare/enwiro-v0.3.56...enwiro-v0.3.57) - 2026-07-08

### Fixed

- spawn the configured listen adapter when multiple ones exist ([#718](https://github.com/kantord/enwiro/pull/718))
</blockquote>

## `enwiro-gui`

<blockquote>

## [0.1.3](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.2...enwiro-gui-v0.1.3) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk, enwiro-daemon
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.37](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.36...enwiro-adapter-i3wm-v0.1.37) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.18...enwiro-adapter-tmux-v0.1.19) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-activitywatch`

<blockquote>

## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.3...enwiro-bridge-activitywatch-v0.1.4) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.29](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.28...enwiro-bridge-rofi-v0.1.29) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.20...enwiro-cookbook-chezmoi-v0.1.21) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.27...enwiro-cookbook-git-v0.1.28) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.25](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.24...enwiro-cookbook-github-v0.1.25) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.17...enwiro-cookbook-obsidian-v0.1.18) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.14...enwiro-garnish-just-v0.1.15) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.15](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.14...enwiro-garnish-submodules-v0.1.15) - 2026-07-08

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).