### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.58"
+version = "0.3.59"
 dependencies = [
  "anyhow",
  "assertables",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-activitywatch"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-gui"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.10.3" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.20" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.11.0" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.21" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.39](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.38...enwiro-adapter-i3wm-v0.1.39) - 2026-07-12
+
+### Added
+
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.38](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.37...enwiro-adapter-i3wm-v0.1.38) - 2026-07-10
 
 ### Other

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.20...enwiro-adapter-tmux-v0.1.21) - 2026-07-12
+
+### Added
+
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.19...enwiro-adapter-tmux-v0.1.20) - 2026-07-10
 
 ### Other

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-activitywatch/CHANGELOG.md
+++ b/enwiro-bridge-activitywatch/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.5...enwiro-bridge-activitywatch-v0.1.6) - 2026-07-12
+
+### Added
+
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.4...enwiro-bridge-activitywatch-v0.1.5) - 2026-07-10
 
 ### Other

--- a/enwiro-bridge-activitywatch/Cargo.toml
+++ b/enwiro-bridge-activitywatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-activitywatch"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "ActivityWatch bridge for enwiro: reports the active enwiro env as aw-server heartbeats"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.30...enwiro-bridge-rofi-v0.1.31) - 2026-07-12
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.30](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.29...enwiro-bridge-rofi-v0.1.30) - 2026-07-10
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.22...enwiro-cookbook-chezmoi-v0.1.23) - 2026-07-12
+
+### Added
+
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.21...enwiro-cookbook-chezmoi-v0.1.22) - 2026-07-10
 
 ### Added

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.29...enwiro-cookbook-git-v0.1.30) - 2026-07-12
+
+### Added
+
+- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- add git cookbook ([#762](https://github.com/kantord/enwiro/pull/762))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.29](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.28...enwiro-cookbook-git-v0.1.29) - 2026-07-10
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.26...enwiro-cookbook-github-v0.1.27) - 2026-07-12
+
+### Added
+
+- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+
 ## [0.1.26](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.25...enwiro-cookbook-github-v0.1.26) - 2026-07-10
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.19...enwiro-cookbook-obsidian-v0.1.20) - 2026-07-12
+
+### Added
+
+- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.1.19](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.18...enwiro-cookbook-obsidian-v0.1.19) - 2026-07-10
 
 ### Added

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.21](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.20...enwiro-daemon-v0.0.21) - 2026-07-12
+
+### Added
+
+- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
+- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Fixed
+
+- *(deps)* update rust crate reqwest to 0.13 ([#744](https://github.com/kantord/enwiro/pull/744))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small metadta fixes ([#733](https://github.com/kantord/enwiro/pull/733))
+
 ## [0.0.20](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.19...enwiro-daemon-v0.0.20) - 2026-07-10
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.20"
+version = "0.0.21"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.16...enwiro-garnish-just-v0.1.17) - 2026-07-12
+
+### Added
+
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+
 ## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.15...enwiro-garnish-just-v0.1.16) - 2026-07-10
 
 ### Other

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.16...enwiro-garnish-submodules-v0.1.17) - 2026-07-12
+
+### Added
+
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+
 ## [0.1.16](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.15...enwiro-garnish-submodules-v0.1.16) - 2026-07-10
 
 ### Other

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-gui/CHANGELOG.md
+++ b/enwiro-gui/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.4...enwiro-gui-v0.1.5) - 2026-07-12
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+- *(deps)* update dependency vite to v8.1.4 ([#746](https://github.com/kantord/enwiro/pull/746))
+- *(deps)* update dependency typescript to v7 ([#740](https://github.com/kantord/enwiro/pull/740))
+- *(deps)* update dependency @types/node to v24.13.3 ([#734](https://github.com/kantord/enwiro/pull/734))
+
 ## [0.1.4](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.3...enwiro-gui-v0.1.4) - 2026-07-10
 
 ### Other

--- a/enwiro-gui/Cargo.toml
+++ b/enwiro-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-gui"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Local web GUI for enwiro: a single binary that serves an embedded React SPA to the browser"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.3...enwiro-sdk-v0.11.0) - 2026-07-12
+
+### Added
+
+- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
+- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
+- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))
+
+### Fixed
+
+- run test fixture scripts via sh to avoid ETXTBSY flake ([#745](https://github.com/kantord/enwiro/pull/745))
+
+### Other
+
+- small metadta fixes ([#733](https://github.com/kantord/enwiro/pull/733))
+
 ## [0.10.3](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.2...enwiro-sdk-v0.10.3) - 2026-07-10
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.59](https://github.com/kantord/enwiro/compare/enwiro-v0.3.58...enwiro-v0.3.59) - 2026-07-12
+
+### Added
+
+- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
+- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
+
+### Other
+
+- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
+- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
+
 ## [0.3.58](https://github.com/kantord/enwiro/compare/enwiro-v0.3.57...enwiro-v0.3.58) - 2026-07-10
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.58"
+version = "0.3.59"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.10.3 -> 0.11.0 (⚠ API breaking changes)
* `enwiro-daemon`: 0.0.20 -> 0.0.21 (✓ API compatible changes)
* `enwiro`: 0.3.58 -> 0.3.59
* `enwiro-gui`: 0.1.4 -> 0.1.5
* `enwiro-adapter-i3wm`: 0.1.38 -> 0.1.39
* `enwiro-adapter-tmux`: 0.1.20 -> 0.1.21
* `enwiro-bridge-activitywatch`: 0.1.5 -> 0.1.6
* `enwiro-bridge-rofi`: 0.1.30 -> 0.1.31
* `enwiro-cookbook-chezmoi`: 0.1.22 -> 0.1.23
* `enwiro-cookbook-git`: 0.1.29 -> 0.1.30
* `enwiro-cookbook-github`: 0.1.26 -> 0.1.27
* `enwiro-cookbook-obsidian`: 0.1.19 -> 0.1.20
* `enwiro-garnish-just`: 0.1.16 -> 0.1.17
* `enwiro-garnish-submodules`: 0.1.16 -> 0.1.17

### ⚠ `enwiro-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CookbookMetadata.capabilities in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/cookbook.rs:36
  field CookbookMetadata.capabilities in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/cookbook.rs:36
  field PatternRecipe.url in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/cookbook.rs:191
  field PatternRecipe.url in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/cookbook.rs:191
  field CachedPatternRecipe.url in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/client.rs:56

--- failure copy_impl_added: type now implements Copy ---

Description:
A public type now implements Copy, causing non-move closures to capture it by reference instead of moving it.
        ref: https://github.com/rust-lang/rust/issues/100905
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/copy_impl_added.ron

Failed in:
  enwiro_sdk::bridge::BridgeCapability in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/bridge.rs:20

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function enwiro_sdk::bridge::fetch_bridge_metadata_with_timeout, previously in file /tmp/.tmp1SdAdM/enwiro-sdk/src/bridge.rs:83

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  BridgeMetadata::has_capability, previously in file /tmp/.tmp1SdAdM/enwiro-sdk/src/bridge.rs:70
  PluginName::gear_filename, previously in file /tmp/.tmp1SdAdM/enwiro-sdk/src/plugin.rs:56

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  enwiro_sdk::bridge::BridgeMetadata::with_capabilities takes 0 generic types instead of 2, in /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/bridge.rs:51

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  LISTEN_CAPABILITY in file /tmp/.tmp1SdAdM/enwiro-sdk/src/bridge.rs:22

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct enwiro_sdk::bridge::BridgeCapability became enum in file /tmp/.tmpvdUI8U/enwiro/enwiro-sdk/src/bridge.rs:20

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method applies_to of trait Garnish, previously in file /tmp/.tmp1SdAdM/enwiro-sdk/src/garnish.rs:39
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.11.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.3...enwiro-sdk-v0.11.0) - 2026-07-12

### Added

- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Fixed

- run test fixture scripts via sh to avoid ETXTBSY flake ([#745](https://github.com/kantord/enwiro/pull/745))

### Other

- small metadta fixes ([#733](https://github.com/kantord/enwiro/pull/733))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.21](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.20...enwiro-daemon-v0.0.21) - 2026-07-12

### Added

- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Fixed

- *(deps)* update rust crate reqwest to 0.13 ([#744](https://github.com/kantord/enwiro/pull/744))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small metadta fixes ([#733](https://github.com/kantord/enwiro/pull/733))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.59](https://github.com/kantord/enwiro/compare/enwiro-v0.3.58...enwiro-v0.3.59) - 2026-07-12

### Added

- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-gui`

<blockquote>

## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.4...enwiro-gui-v0.1.5) - 2026-07-12

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
- *(deps)* update dependency vite to v8.1.4 ([#746](https://github.com/kantord/enwiro/pull/746))
- *(deps)* update dependency typescript to v7 ([#740](https://github.com/kantord/enwiro/pull/740))
- *(deps)* update dependency @types/node to v24.13.3 ([#734](https://github.com/kantord/enwiro/pull/734))
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.39](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.38...enwiro-adapter-i3wm-v0.1.39) - 2026-07-12

### Added

- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.20...enwiro-adapter-tmux-v0.1.21) - 2026-07-12

### Added

- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-bridge-activitywatch`

<blockquote>

## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.5...enwiro-bridge-activitywatch-v0.1.6) - 2026-07-12

### Added

- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.31](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.30...enwiro-bridge-rofi-v0.1.31) - 2026-07-12

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.22...enwiro-cookbook-chezmoi-v0.1.23) - 2026-07-12

### Added

- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.30](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.29...enwiro-cookbook-git-v0.1.30) - 2026-07-12

### Added

- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- add git cookbook ([#762](https://github.com/kantord/enwiro/pull/762))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.26...enwiro-cookbook-github-v0.1.27) - 2026-07-12

### Added

- add browser extension ([#739](https://github.com/kantord/enwiro/pull/739))
- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.19...enwiro-cookbook-obsidian-v0.1.20) - 2026-07-12

### Added

- allow combining multiple environments ([#761](https://github.com/kantord/enwiro/pull/761))
- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
- small fixes ([#748](https://github.com/kantord/enwiro/pull/748))
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.16...enwiro-garnish-just-v0.1.17) - 2026-07-12

### Added

- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.16...enwiro-garnish-submodules-v0.1.17) - 2026-07-12

### Added

- unify metadata behavior ([#728](https://github.com/kantord/enwiro/pull/728))

### Other

- set up binary publishing ([#765](https://github.com/kantord/enwiro/pull/765))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).