### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro"
-version = "0.3.59"
+version = "0.3.60"
 dependencies = [
  "anyhow",
  "assertables",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-i3wm"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-adapter-tmux"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-activitywatch"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-bridge-rofi"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "enwiro-sdk",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-git"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-github"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-daemon"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-just"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-garnish-submodules"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-gui"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "enwiro-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ members = [
 repository = "https://github.com/kantord/enwiro"
 
 [workspace.dependencies]
-enwiro-sdk = { path = "enwiro-sdk", version = "0.11.0" }
-enwiro-daemon = { path = "enwiro-daemon", version = "0.0.21" }
+enwiro-sdk = { path = "enwiro-sdk", version = "0.12.0" }
+enwiro-daemon = { path = "enwiro-daemon", version = "0.0.22" }
 home = "0.5.9"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/enwiro-adapter-i3wm/CHANGELOG.md
+++ b/enwiro-adapter-i3wm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.40](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.39...enwiro-adapter-i3wm-v0.1.40) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.39](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.38...enwiro-adapter-i3wm-v0.1.39) - 2026-07-12
 
 ### Added

--- a/enwiro-adapter-i3wm/Cargo.toml
+++ b/enwiro-adapter-i3wm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-i3wm"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2024"
 description = "i3wm adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-adapter-tmux/CHANGELOG.md
+++ b/enwiro-adapter-tmux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.21...enwiro-adapter-tmux-v0.1.22) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.20...enwiro-adapter-tmux-v0.1.21) - 2026-07-12
 
 ### Added

--- a/enwiro-adapter-tmux/Cargo.toml
+++ b/enwiro-adapter-tmux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-adapter-tmux"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 description = "tmux adapter for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-activitywatch/CHANGELOG.md
+++ b/enwiro-bridge-activitywatch/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.6...enwiro-bridge-activitywatch-v0.1.7) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.5...enwiro-bridge-activitywatch-v0.1.6) - 2026-07-12
 
 ### Added

--- a/enwiro-bridge-activitywatch/Cargo.toml
+++ b/enwiro-bridge-activitywatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-activitywatch"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "ActivityWatch bridge for enwiro: reports the active enwiro env as aw-server heartbeats"
 license = "GPL-3.0-or-later"

--- a/enwiro-bridge-rofi/CHANGELOG.md
+++ b/enwiro-bridge-rofi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.31...enwiro-bridge-rofi-v0.1.32) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.31](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.30...enwiro-bridge-rofi-v0.1.31) - 2026-07-12
 
 ### Other

--- a/enwiro-bridge-rofi/Cargo.toml
+++ b/enwiro-bridge-rofi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-bridge-rofi"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2024"
 description = "Rofi bridge for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-chezmoi/CHANGELOG.md
+++ b/enwiro-cookbook-chezmoi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.23...enwiro-cookbook-chezmoi-v0.1.24) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.23](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.22...enwiro-cookbook-chezmoi-v0.1.23) - 2026-07-12
 
 ### Added

--- a/enwiro-cookbook-chezmoi/Cargo.toml
+++ b/enwiro-cookbook-chezmoi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-chezmoi"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 description = "Chezmoi cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-git/CHANGELOG.md
+++ b/enwiro-cookbook-git/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.31](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.30...enwiro-cookbook-git-v0.1.31) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.30](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.29...enwiro-cookbook-git-v0.1.30) - 2026-07-12
 
 ### Added

--- a/enwiro-cookbook-git/Cargo.toml
+++ b/enwiro-cookbook-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-git"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 description = "i3wm cookbook for git"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-github/CHANGELOG.md
+++ b/enwiro-cookbook-github/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.27...enwiro-cookbook-github-v0.1.28) - 2026-07-13
+
+### Added
+
+- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
+
 ## [0.1.27](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.26...enwiro-cookbook-github-v0.1.27) - 2026-07-12
 
 ### Added

--- a/enwiro-cookbook-github/Cargo.toml
+++ b/enwiro-cookbook-github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-github"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2024"
 description = "GitHub PR cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-cookbook-obsidian/CHANGELOG.md
+++ b/enwiro-cookbook-obsidian/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.20...enwiro-cookbook-obsidian-v0.1.21) - 2026-07-13
+
+### Added
+
+- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
+
 ## [0.1.20](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.19...enwiro-cookbook-obsidian-v0.1.20) - 2026-07-12
 
 ### Added

--- a/enwiro-cookbook-obsidian/Cargo.toml
+++ b/enwiro-cookbook-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-cookbook-obsidian"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 description = "Obsidian vault cookbook for enwiro"
 license = "GPL-3.0-or-later"

--- a/enwiro-daemon/CHANGELOG.md
+++ b/enwiro-daemon/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.22](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.21...enwiro-daemon-v0.0.22) - 2026-07-13
+
+### Added
+
+- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
+
+### Fixed
+
+- avoid silent connection errors ([#767](https://github.com/kantord/enwiro/pull/767))
+
 ## [0.0.21](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.20...enwiro-daemon-v0.0.21) - 2026-07-12
 
 ### Added

--- a/enwiro-daemon/Cargo.toml
+++ b/enwiro-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-daemon"
-version = "0.0.21"
+version = "0.0.22"
 edition = "2024"
 description = "Background daemon for enwiro: refreshes the recipe cache and forwards workspace switch events"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-just/CHANGELOG.md
+++ b/enwiro-garnish-just/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.17...enwiro-garnish-just-v0.1.18) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.16...enwiro-garnish-just-v0.1.17) - 2026-07-12
 
 ### Added

--- a/enwiro-garnish-just/Cargo.toml
+++ b/enwiro-garnish-just/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-just"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "Garnish that surfaces `just` recipes as enwiro CLI gear"
 license = "GPL-3.0-or-later"

--- a/enwiro-garnish-submodules/CHANGELOG.md
+++ b/enwiro-garnish-submodules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.17...enwiro-garnish-submodules-v0.1.18) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk
+
 ## [0.1.17](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.16...enwiro-garnish-submodules-v0.1.17) - 2026-07-12
 
 ### Added

--- a/enwiro-garnish-submodules/Cargo.toml
+++ b/enwiro-garnish-submodules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-garnish-submodules"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "Garnish that initialises git submodules on env cook"
 license = "GPL-3.0-or-later"

--- a/enwiro-gui/CHANGELOG.md
+++ b/enwiro-gui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.5...enwiro-gui-v0.1.6) - 2026-07-13
+
+### Other
+
+- updated the following local packages: enwiro-sdk, enwiro-daemon
+
 ## [0.1.5](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.4...enwiro-gui-v0.1.5) - 2026-07-12
 
 ### Other

--- a/enwiro-gui/Cargo.toml
+++ b/enwiro-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-gui"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Local web GUI for enwiro: a single binary that serves an embedded React SPA to the browser"
 license = "GPL-3.0-or-later"

--- a/enwiro-sdk/CHANGELOG.md
+++ b/enwiro-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.11.0...enwiro-sdk-v0.12.0) - 2026-07-13
+
+### Added
+
+- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
+
 ## [0.11.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.10.3...enwiro-sdk-v0.11.0) - 2026-07-12
 
 ### Added

--- a/enwiro-sdk/Cargo.toml
+++ b/enwiro-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro-sdk"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Shared SDK for enwiro plugin authors: logging, gear schema, plugin protocol types"
 license = "GPL-3.0-or-later"

--- a/enwiro/CHANGELOG.md
+++ b/enwiro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.60](https://github.com/kantord/enwiro/compare/enwiro-v0.3.59...enwiro-v0.3.60) - 2026-07-13
+
+### Added
+
+- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
+
 ## [0.3.59](https://github.com/kantord/enwiro/compare/enwiro-v0.3.58...enwiro-v0.3.59) - 2026-07-12
 
 ### Added

--- a/enwiro/Cargo.toml
+++ b/enwiro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enwiro"
-version = "0.3.59"
+version = "0.3.60"
 edition = "2024"
 description = "Simplify your workflow with dedicated project environments for each workspace in your window manager"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `enwiro-sdk`: 0.11.0 -> 0.12.0 (⚠ API breaking changes)
* `enwiro-daemon`: 0.0.21 -> 0.0.22 (✓ API compatible changes)
* `enwiro`: 0.3.59 -> 0.3.60
* `enwiro-cookbook-github`: 0.1.27 -> 0.1.28
* `enwiro-cookbook-obsidian`: 0.1.20 -> 0.1.21
* `enwiro-gui`: 0.1.5 -> 0.1.6
* `enwiro-adapter-i3wm`: 0.1.39 -> 0.1.40
* `enwiro-adapter-tmux`: 0.1.21 -> 0.1.22
* `enwiro-bridge-activitywatch`: 0.1.6 -> 0.1.7
* `enwiro-bridge-rofi`: 0.1.31 -> 0.1.32
* `enwiro-cookbook-chezmoi`: 0.1.23 -> 0.1.24
* `enwiro-cookbook-git`: 0.1.30 -> 0.1.31
* `enwiro-garnish-just`: 0.1.17 -> 0.1.18
* `enwiro-garnish-submodules`: 0.1.17 -> 0.1.18

### ⚠ `enwiro-sdk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Recipe.goal in /tmp/.tmpAToMC5/enwiro/enwiro-sdk/src/cookbook.rs:158
  field Recipe.goal in /tmp/.tmpAToMC5/enwiro/enwiro-sdk/src/cookbook.rs:158
  field CachedRecipe.goal in /tmp/.tmpAToMC5/enwiro/enwiro-sdk/src/client.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `enwiro-sdk`

<blockquote>

## [0.12.0](https://github.com/kantord/enwiro/compare/enwiro-sdk-v0.11.0...enwiro-sdk-v0.12.0) - 2026-07-13

### Added

- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
</blockquote>

## `enwiro-daemon`

<blockquote>

## [0.0.22](https://github.com/kantord/enwiro/compare/enwiro-daemon-v0.0.21...enwiro-daemon-v0.0.22) - 2026-07-13

### Added

- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))

### Fixed

- avoid silent connection errors ([#767](https://github.com/kantord/enwiro/pull/767))
</blockquote>

## `enwiro`

<blockquote>

## [0.3.60](https://github.com/kantord/enwiro/compare/enwiro-v0.3.59...enwiro-v0.3.60) - 2026-07-13

### Added

- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
</blockquote>

## `enwiro-cookbook-github`

<blockquote>

## [0.1.28](https://github.com/kantord/enwiro/compare/enwiro-cookbook-github-v0.1.27...enwiro-cookbook-github-v0.1.28) - 2026-07-13

### Added

- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
</blockquote>

## `enwiro-cookbook-obsidian`

<blockquote>

## [0.1.21](https://github.com/kantord/enwiro/compare/enwiro-cookbook-obsidian-v0.1.20...enwiro-cookbook-obsidian-v0.1.21) - 2026-07-13

### Added

- add the concept of goal tracking ([#768](https://github.com/kantord/enwiro/pull/768))
</blockquote>

## `enwiro-gui`

<blockquote>

## [0.1.6](https://github.com/kantord/enwiro/compare/enwiro-gui-v0.1.5...enwiro-gui-v0.1.6) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk, enwiro-daemon
</blockquote>

## `enwiro-adapter-i3wm`

<blockquote>

## [0.1.40](https://github.com/kantord/enwiro/compare/enwiro-adapter-i3wm-v0.1.39...enwiro-adapter-i3wm-v0.1.40) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-adapter-tmux`

<blockquote>

## [0.1.22](https://github.com/kantord/enwiro/compare/enwiro-adapter-tmux-v0.1.21...enwiro-adapter-tmux-v0.1.22) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-activitywatch`

<blockquote>

## [0.1.7](https://github.com/kantord/enwiro/compare/enwiro-bridge-activitywatch-v0.1.6...enwiro-bridge-activitywatch-v0.1.7) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-bridge-rofi`

<blockquote>

## [0.1.32](https://github.com/kantord/enwiro/compare/enwiro-bridge-rofi-v0.1.31...enwiro-bridge-rofi-v0.1.32) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-chezmoi`

<blockquote>

## [0.1.24](https://github.com/kantord/enwiro/compare/enwiro-cookbook-chezmoi-v0.1.23...enwiro-cookbook-chezmoi-v0.1.24) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-cookbook-git`

<blockquote>

## [0.1.31](https://github.com/kantord/enwiro/compare/enwiro-cookbook-git-v0.1.30...enwiro-cookbook-git-v0.1.31) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-just`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-garnish-just-v0.1.17...enwiro-garnish-just-v0.1.18) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>

## `enwiro-garnish-submodules`

<blockquote>

## [0.1.18](https://github.com/kantord/enwiro/compare/enwiro-garnish-submodules-v0.1.17...enwiro-garnish-submodules-v0.1.18) - 2026-07-13

### Other

- updated the following local packages: enwiro-sdk
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).